### PR TITLE
Pass full convolution distribution to result accumulators

### DIFF
--- a/src/ResourceAdequacy/simulations/convolution/Convolution.jl
+++ b/src/ResourceAdequacy/simulations/convolution/Convolution.jl
@@ -58,8 +58,8 @@ function assess(
     for t in periods
 
         # TODO: Deduplicate identical available capacity distributions?
-        lolp, eul = assess(CapacityDistribution(system, t))
-        update!(acc, t, lolp, eul)
+        distr = CapacityDistribution(system, t)
+        update!(acc, t, distr)
 
     end
 

--- a/src/ResourceAdequacy/simulations/convolution/result_minimal.jl
+++ b/src/ResourceAdequacy/simulations/convolution/result_minimal.jl
@@ -13,9 +13,10 @@ accumulator(::Convolution, ::Minimal, ::SystemModel{N,L,T,P,E}) where {N,L,T,P,E
 
 function update!(
     acc::ConvolutionMinimalAccumulator,
-    t::Int, lolp::Float64, eul::Float64
+    t::Int, distr::CapacityDistribution
 )
 
+    lolp, eul = assess(distr)
     acc.lole += lolp
     acc.eul += eul
     return

--- a/src/ResourceAdequacy/simulations/convolution/result_temporal.jl
+++ b/src/ResourceAdequacy/simulations/convolution/result_temporal.jl
@@ -16,8 +16,10 @@ accumulator(::Convolution, ::Temporal, ::SystemModel{N,L,T,P,E}) where {N,L,T,P,
 
 function update!(
     acc::ConvolutionTemporalAccumulator,
-    t::Int, lolp::Float64, eul::Float64
+    t::Int,  distr::CapacityDistribution
 )
+
+    lolp, eul = assess(distr)
 
     acc.lole += lolp
     acc.lolps[t] = lolp


### PR DESCRIPTION
This provides more information for `ResultSpec`s to work with.