### PR TITLE
Eliminate some rogue memory-allocating operations

### DIFF
--- a/src/ResourceAdequacy/simulations/sequentialmontecarlo/DispatchProblem.jl
+++ b/src/ResourceAdequacy/simulations/sequentialmontecarlo/DispatchProblem.jl
@@ -277,8 +277,8 @@ function update_problem!(
         dischargeefficiency = system.storages.discharge_efficiency[i, t]
         energydischargeable = stor_energy * dischargeefficiency
 
-        if maxdischarge == 0
-            timetodischarge = length(system.timestamps) + 1
+        if iszero(maxdischarge)
+            timetodischarge = N + 1
         else
             timetodischarge = round(Int, energydischargeable / maxdischarge)
         end
@@ -340,8 +340,8 @@ function update_problem!(
         dischargeefficiency = system.generatorstorages.discharge_efficiency[i, t]
         energydischargeable = stor_energy * dischargeefficiency
 
-        if maxdischarge == 0
-            timetodischarge = length(system.timestamps) + 1
+        if iszero(maxdischarge)
+            timetodischarge = N + 1
         else
             timetodischarge = round(Int, energydischargeable / maxdischarge)
         end

--- a/src/ResourceAdequacy/simulations/sequentialmontecarlo/SequentialMonteCarlo.jl
+++ b/src/ResourceAdequacy/simulations/sequentialmontecarlo/SequentialMonteCarlo.jl
@@ -81,26 +81,24 @@ function assess(
 end
 
 function initialize!(
-    rng::AbstractRNG, state::SystemState, system::SystemModel
-)
-
-        nperiods = length(system.timestamps)
+    rng::AbstractRNG, state::SystemState, system::SystemModel{N}
+) where N
 
         initialize_availability!(
             rng, state.gens_available, state.gens_nexttransition,
-            system.generators, nperiods)
+            system.generators, N)
 
         initialize_availability!(
             rng, state.stors_available, state.stors_nexttransition,
-            system.storages, nperiods)
+            system.storages, N)
 
         initialize_availability!(
             rng, state.genstors_available, state.genstors_nexttransition,
-            system.generatorstorages, nperiods)
+            system.generatorstorages, N)
 
         initialize_availability!(
             rng, state.lines_available, state.lines_nexttransition,
-            system.lines, nperiods)
+            system.lines, N)
 
         fill!(state.stors_energy, 0)
         fill!(state.genstors_energy, 0)
@@ -113,25 +111,23 @@ function advance!(
     rng::AbstractRNG,
     state::SystemState,
     dispatchproblem::DispatchProblem,
-    system::SystemModel, t::Int)
-
-    nperiods = length(system.timestamps)
+    system::SystemModel{N}, t::Int) where N
 
     update_availability!(
         rng, state.gens_available, state.gens_nexttransition,
-        system.generators, t, nperiods)
+        system.generators, t, N)
 
     update_availability!(
         rng, state.stors_available, state.stors_nexttransition,
-        system.storages, t, nperiods)
+        system.storages, t, N)
 
     update_availability!(
         rng, state.genstors_available, state.genstors_nexttransition,
-        system.generatorstorages, t, nperiods)
+        system.generatorstorages, t, N)
 
     update_availability!(
         rng, state.lines_available, state.lines_nexttransition,
-        system.lines, t, nperiods)
+        system.lines, t, N)
 
     update_energy!(state.stors_energy, system.storages, t)
     update_energy!(state.genstors_energy, system.generatorstorages, t)
@@ -144,7 +140,6 @@ function solve!(
     dispatchproblem::DispatchProblem, state::SystemState,
     system::SystemModel, t::Int
 )
-    fp = dispatchproblem.fp
     solveflows!(dispatchproblem.fp)
     update_state!(state, dispatchproblem, system, t)
 end

--- a/src/ResourceAdequacy/simulations/sequentialmontecarlo/utils.jl
+++ b/src/ResourceAdequacy/simulations/sequentialmontecarlo/utils.jl
@@ -43,8 +43,8 @@ function randtransitiontime(
     i::Int, t_now::Int, t_last::Int
 )
 
-    cdf = 0
-    p_noprevtransition = 1
+    cdf = 0.
+    p_noprevtransition = 1.
 
     x = rand(rng)
     t = t_now + 1
@@ -53,7 +53,7 @@ function randtransitiontime(
         p_it = p[i,t]
         cdf += p_noprevtransition * p_it
         x < cdf && return t
-        p_noprevtransition *= (1 - p_it)
+        p_noprevtransition *= (1. - p_it)
         t += 1
     end
 
@@ -87,10 +87,11 @@ function available_capacity(
     idxs::UnitRange{Int}, t::Int
 )
 
+    caps = gens.capacity
     avcap = 0
 
     for i in idxs
-        availability[i] && (avcap += gens.capacity[i, t])
+        availability[i] && (avcap += caps[i, t])
     end
 
     return avcap


### PR DESCRIPTION
Should provide much steadier memory consumption and performance benefits associated with avoided allocations/deallocations