### PR TITLE
Fix interface utilization NaNs

### DIFF
--- a/src/ResourceAdequacy/simulations/sequentialmontecarlo/result_debug.jl
+++ b/src/ResourceAdequacy/simulations/sequentialmontecarlo/result_debug.jl
@@ -142,7 +142,24 @@ function record!(
         max_back = edges[f].limit
 
         fit!(acc.flows[i,t], max(flow_forward, flow_back))
-        fit!(acc.utilizations[i,t], max(flow_forward/max_forward, flow_back/max_back))
+
+        if flow_forward > 0
+
+            fit!(acc.utilizations[i,t], flow_forward/max_forward)
+
+        elseif flow_back > 0
+
+            fit!(acc.utilizations[i,t], flow_back/max_back)
+
+        elseif iszero(max_forward) && iszero(max_back)
+
+            fit!(acc.utilizations[i,t], 1.0)
+
+        else
+
+            fit!(acc.utilizations[i,t], 0.0)
+
+        end
 
     end
 

--- a/src/ResourceAdequacy/simulations/sequentialmontecarlo/result_network.jl
+++ b/src/ResourceAdequacy/simulations/sequentialmontecarlo/result_network.jl
@@ -120,7 +120,24 @@ function record!(
         max_back = edges[f].limit
 
         fit!(acc.flows[i,t], max(flow_forward, flow_back))
-        fit!(acc.utilizations[i,t], max(flow_forward/max_forward, flow_back/max_back))
+
+        if flow_forward > 0
+
+            fit!(acc.utilizations[i,t], flow_forward/max_forward)
+
+        elseif flow_back > 0
+
+            fit!(acc.utilizations[i,t], flow_back/max_back)
+
+        elseif iszero(max_forward) && iszero(max_back)
+
+            fit!(acc.utilizations[i,t], 1.0)
+
+        else
+
+            fit!(acc.utilizations[i,t], 0.0)
+
+        end
 
     end
 


### PR DESCRIPTION
Better handle the case where all lines in an interface go on outage, leading to 0/0 = NaN% utilization.

Should add tests involving line outages before merging.