### PR TITLE
Implement colon result indexing where not ambiguous

### DIFF
--- a/src/ResourceAdequacy/results/availability.jl
+++ b/src/ResourceAdequacy/results/availability.jl
@@ -1,8 +1,21 @@
+abstract type AbstractAvailabilityResult{N,L,T} <: Result{N,L,T} end
+
+# Colon indexing
+
+getindex(x::AbstractAvailabilityResult, ::Colon, t::ZonedDateTime) =
+    getindex.(x, names(x), t)
+
+getindex(x::AbstractAvailabilityResult, name::String, ::Colon) =
+    getindex.(x, name, x.timestamps)
+
+getindex(x::AbstractAvailabilityResult, ::Colon, ::Colon) =
+    getindex.(x, names(x), permutedims(x.timestamps))
+
 # Full Generator availability data
 
 struct GeneratorAvailability <: ResultSpec end
 
-struct GeneratorAvailabilityResult{N,L,T<:Period} <: Result{N,L,T}
+struct GeneratorAvailabilityResult{N,L,T<:Period} <: AbstractAvailabilityResult{N,L,T}
 
     generators::Vector{String}
     timestamps::StepRange{ZonedDateTime,T}
@@ -10,6 +23,8 @@ struct GeneratorAvailabilityResult{N,L,T<:Period} <: Result{N,L,T}
     available::Array{Bool,3}
 
 end
+
+names(x::GeneratorAvailabilityResult) = x.generators
 
 function getindex(x::GeneratorAvailabilityResult, g::AbstractString, t::ZonedDateTime)
     i_g = findfirstunique(x.generators, g)
@@ -21,7 +36,7 @@ end
 
 struct StorageAvailability <: ResultSpec end
 
-struct StorageAvailabilityResult{N,L,T<:Period} <: Result{N,L,T}
+struct StorageAvailabilityResult{N,L,T<:Period} <: AbstractAvailabilityResult{N,L,T}
 
     storages::Vector{String}
     timestamps::StepRange{ZonedDateTime,T}
@@ -29,6 +44,8 @@ struct StorageAvailabilityResult{N,L,T<:Period} <: Result{N,L,T}
     available::Array{Bool,3}
 
 end
+
+names(x::StorageAvailabilityResult) = x.storages
 
 function getindex(x::StorageAvailabilityResult, s::AbstractString, t::ZonedDateTime)
     i_s = findfirstunique(x.storages, s)
@@ -40,7 +57,7 @@ end
 
 struct GeneratorStorageAvailability <: ResultSpec end
 
-struct GeneratorStorageAvailabilityResult{N,L,T<:Period} <: Result{N,L,T}
+struct GeneratorStorageAvailabilityResult{N,L,T<:Period} <: AbstractAvailabilityResult{N,L,T}
 
     generatorstorages::Vector{String}
     timestamps::StepRange{ZonedDateTime,T}
@@ -48,6 +65,8 @@ struct GeneratorStorageAvailabilityResult{N,L,T<:Period} <: Result{N,L,T}
     available::Array{Bool,3}
 
 end
+
+names(x::GeneratorStorageAvailabilityResult) = x.generatorstorages
 
 function getindex(x::GeneratorStorageAvailabilityResult, gs::AbstractString, t::ZonedDateTime)
     i_gs = findfirstunique(x.generatorstorages, gs)
@@ -59,7 +78,7 @@ end
 
 struct LineAvailability <: ResultSpec end
 
-struct LineAvailabilityResult{N,L,T<:Period} <: Result{N,L,T}
+struct LineAvailabilityResult{N,L,T<:Period} <: AbstractAvailabilityResult{N,L,T}
 
     lines::Vector{String}
     timestamps::StepRange{ZonedDateTime,T}
@@ -67,6 +86,8 @@ struct LineAvailabilityResult{N,L,T<:Period} <: Result{N,L,T}
     available::Array{Bool,3}
 
 end
+
+names(x::LineAvailabilityResult) = x.lines
 
 function getindex(x::LineAvailabilityResult, l::AbstractString, t::ZonedDateTime)
     i_l = findfirstunique(x.lines, l)

--- a/src/ResourceAdequacy/results/energy.jl
+++ b/src/ResourceAdequacy/results/energy.jl
@@ -1,8 +1,24 @@
+abstract type AbstractEnergyResult{N,L,T} <: Result{N,L,T} end
+
+# Colon indexing
+
+getindex(x::AbstractEnergyResult, ::Colon) =
+    getindex.(x, x.timestamps)
+
+getindex(x::AbstractEnergyResult, ::Colon, t::ZonedDateTime) =
+    getindex.(x, names(x), t)
+
+getindex(x::AbstractEnergyResult, name::String, ::Colon) =
+    getindex.(x, name, x.timestamps)
+
+getindex(x::AbstractEnergyResult, ::Colon, ::Colon) =
+    getindex.(x, names(x), permutedims(x.timestamps))
+
 # Sample-averaged Storage state-of-charge data
 
 struct StorageEnergy <: ResultSpec end
 
-struct StorageEnergyResult{N,L,T<:Period,E<:EnergyUnit} <: Result{N,L,T}
+struct StorageEnergyResult{N,L,T<:Period,E<:EnergyUnit} <: AbstractEnergyResult{N,L,T}
 
     nsamples::Union{Int,Nothing}
     storages::Vector{String}
@@ -14,6 +30,8 @@ struct StorageEnergyResult{N,L,T<:Period,E<:EnergyUnit} <: Result{N,L,T}
     energy_regionperiod_std::Matrix{Float64}
 
 end
+
+names(x::StorageEnergyResult) = x.storages
 
 function getindex(x::StorageEnergyResult, t::ZonedDateTime)
     i_t = findfirstunique(x.timestamps, t)
@@ -30,7 +48,7 @@ end
 
 struct GeneratorStorageEnergy <: ResultSpec end
 
-struct GeneratorStorageEnergyResult{N,L,T<:Period,E<:EnergyUnit} <: Result{N,L,T}
+struct GeneratorStorageEnergyResult{N,L,T<:Period,E<:EnergyUnit} <: AbstractEnergyResult{N,L,T}
 
     nsamples::Union{Int,Nothing}
     generatorstorages::Vector{String}
@@ -42,6 +60,8 @@ struct GeneratorStorageEnergyResult{N,L,T<:Period,E<:EnergyUnit} <: Result{N,L,T
     energy_regionperiod_std::Matrix{Float64}
 
 end
+
+names(x::GeneratorStorageEnergyResult) = x.generatorstorages
 
 function getindex(x::GeneratorStorageEnergyResult, t::ZonedDateTime)
     i_t = findfirstunique(x.timestamps, t)
@@ -58,7 +78,7 @@ end
 
 struct StorageEnergySamples <: ResultSpec end
 
-struct StorageEnergySamplesResult{N,L,T<:Period,E<:EnergyUnit} <: Result{N,L,T}
+struct StorageEnergySamplesResult{N,L,T<:Period,E<:EnergyUnit} <: AbstractEnergyResult{N,L,T}
 
     storages::Vector{String}
     timestamps::StepRange{ZonedDateTime,T}
@@ -66,6 +86,8 @@ struct StorageEnergySamplesResult{N,L,T<:Period,E<:EnergyUnit} <: Result{N,L,T}
     energy::Array{Int,3}
 
 end
+
+names(x::StorageEnergySamplesResult) = x.storages
 
 function getindex(x::StorageEnergySamplesResult, t::ZonedDateTime)
     i_t = findfirstunique(x.timestamps, t)
@@ -82,7 +104,7 @@ end
 
 struct GeneratorStorageEnergySamples <: ResultSpec end
 
-struct GeneratorStorageEnergySamplesResult{N,L,T<:Period,E<:EnergyUnit} <: Result{N,L,T}
+struct GeneratorStorageEnergySamplesResult{N,L,T<:Period,E<:EnergyUnit} <: AbstractEnergyResult{N,L,T}
 
     generatorstorages::Vector{String}
     timestamps::StepRange{ZonedDateTime,T}
@@ -90,6 +112,8 @@ struct GeneratorStorageEnergySamplesResult{N,L,T<:Period,E<:EnergyUnit} <: Resul
     energy::Array{Int,3}
 
 end
+
+names(x::GeneratorStorageEnergySamplesResult) = x.generatorstorages
 
 function getindex(x::GeneratorStorageEnergySamplesResult, t::ZonedDateTime)
     i_t = findfirstunique(x.timestamps, t)

--- a/src/ResourceAdequacy/results/flow.jl
+++ b/src/ResourceAdequacy/results/flow.jl
@@ -1,8 +1,23 @@
+struct Flow <: ResultSpec end
+abstract type AbstractFlowResult{N,L,T} <: Result{N,L,T} end
+
+# Colon indexing
+
+getindex(x::AbstractFlowResult, ::Colon) =
+    getindex.(x, x.interfaces)
+
+getindex(x::AbstractFlowResult, ::Colon, t::ZonedDateTime) =
+    getindex.(x, x.interfaces, t)
+
+getindex(x::AbstractFlowResult, i::Pair{<:AbstractString,<:AbstractString}, ::Colon) =
+    getindex.(x, i, x.timestamps)
+
+getindex(x::AbstractFlowResult, ::Colon, ::Colon) =
+    getindex.(x, x.interfaces, permutedims(x.timestamps))
+
 # Sample-averaged flow data
 
-struct Flow <: ResultSpec end
-
-struct FlowResult{N,L,T<:Period,P<:PowerUnit} <: Result{N,L,T}
+struct FlowResult{N,L,T<:Period,P<:PowerUnit} <: AbstractFlowResult{N,L,T}
 
     nsamples::Union{Int,Nothing}
     interfaces::Vector{Pair{String,String}}
@@ -32,7 +47,7 @@ end
 
 struct FlowSamples <: ResultSpec end
 
-struct FlowSamplesResult{N,L,T<:Period,P<:PowerUnit} <: Result{N,L,T}
+struct FlowSamplesResult{N,L,T<:Period,P<:PowerUnit} <: AbstractFlowResult{N,L,T}
 
     interfaces::Vector{Pair{String,String}}
     timestamps::StepRange{ZonedDateTime,T}

--- a/src/ResourceAdequacy/results/surplus.jl
+++ b/src/ResourceAdequacy/results/surplus.jl
@@ -1,8 +1,23 @@
+struct Surplus <: ResultSpec end
+abstract type AbstractSurplusResult{N,L,T} <: Result{N,L,T} end
+
+# Colon indexing
+
+getindex(x::AbstractSurplusResult, ::Colon) =
+    getindex.(x, x.timestamps)
+
+getindex(x::AbstractSurplusResult, ::Colon, t::ZonedDateTime) =
+    getindex.(x, x.regions, t)
+
+getindex(x::AbstractSurplusResult, r::AbstractString, ::Colon) =
+    getindex.(x, r, x.timestamps)
+
+getindex(x::AbstractSurplusResult, ::Colon, ::Colon) =
+    getindex.(x, x.regions, permutedims(x.timestamps))
+
 # Sample-averaged surplus data
 
-struct Surplus <: ResultSpec end
-
-struct SurplusResult{N,L,T<:Period,P<:PowerUnit} <: Result{N,L,T}
+struct SurplusResult{N,L,T<:Period,P<:PowerUnit} <: AbstractSurplusResult{N,L,T}
 
     nsamples::Union{Int,Nothing}
     regions::Vector{String}
@@ -30,7 +45,7 @@ end
 
 struct SurplusSamples <: ResultSpec end
 
-struct SurplusSamplesResult{N,L,T<:Period,P<:PowerUnit} <: Result{N,L,T}
+struct SurplusSamplesResult{N,L,T<:Period,P<:PowerUnit} <: AbstractSurplusResult{N,L,T}
 
     regions::Vector{String}
     timestamps::StepRange{ZonedDateTime,T}

--- a/src/ResourceAdequacy/results/utilization.jl
+++ b/src/ResourceAdequacy/results/utilization.jl
@@ -1,8 +1,23 @@
+struct Utilization <: ResultSpec end
+abstract type AbstractUtilizationResult{N,L,T} <: Result{N,L,T} end
+
+# Colon indexing
+
+getindex(x::AbstractUtilizationResult, ::Colon) =
+    getindex.(x, x.interfaces)
+
+getindex(x::AbstractUtilizationResult, ::Colon, t::ZonedDateTime) =
+    getindex.(x, x.interfaces, t)
+
+getindex(x::AbstractUtilizationResult, i::Pair{<:AbstractString,<:AbstractString}, ::Colon) =
+    getindex.(x, i, x.timestamps)
+
+getindex(x::AbstractUtilizationResult, ::Colon, ::Colon) =
+    getindex.(x, x.interfaces, permutedims(x.timestamps))
+
 # Sample-averaged utilization data
 
-struct Utilization <: ResultSpec end
-
-struct UtilizationResult{N,L,T<:Period} <: Result{N,L,T}
+struct UtilizationResult{N,L,T<:Period} <: AbstractUtilizationResult{N,L,T}
 
     nsamples::Union{Int,Nothing}
     interfaces::Vector{Pair{String,String}}
@@ -30,7 +45,7 @@ end
 
 struct UtilizationSamples <: ResultSpec end
 
-struct UtilizationSamplesResult{N,L,T<:Period} <: Result{N,L,T}
+struct UtilizationSamplesResult{N,L,T<:Period} <: AbstractUtilizationResult{N,L,T}
 
     interfaces::Vector{Pair{String,String}}
     timestamps::StepRange{ZonedDateTime,T}

--- a/test/ResourceAdequacy/simulation/sequentialmontecarlo.jl
+++ b/test/ResourceAdequacy/simulation/sequentialmontecarlo.jl
@@ -14,11 +14,17 @@
                    FlowSamples(), UtilizationSamples(),
                    GeneratorAvailability())
 
-    timestampcol_a = collect(TestSystems.singlenode_a.timestamps)
-    timestampcol_a5 = collect(TestSystems.singlenode_a_5min.timestamps)
-    timestampcol_b = collect(TestSystems.singlenode_b.timestamps)
-    timestampcol_3 = collect(TestSystems.threenode.timestamps)
-    regionsrow = reshape(TestSystems.threenode.regions.names, 1, :)
+    timestamps_a = TestSystems.singlenode_a.timestamps
+    timestamps_a5 = TestSystems.singlenode_a_5min.timestamps
+    timestamps_b = TestSystems.singlenode_b.timestamps
+    timestamps_3 = TestSystems.threenode.timestamps
+
+    timestamprow_a = permutedims(timestamps_a)
+    timestamprow_a5 = permutedims(timestamps_a5)
+    timestamprow_b = permutedims(timestamps_b)
+    timestamprow_3 = permutedims(timestamps_3)
+
+    regionscol = TestSystems.threenode.regions.names
 
     assess(TestSystems.singlenode_a, smallsample, resultspecs...)
     shortfall_1a, _, flow_1a, util_1a,
@@ -58,22 +64,22 @@
         @test withinrange(EUE(shortfall_1a, "Region"),
                           TestSystems.singlenode_a_eue, nstderr_tol)
 
-        @test all(LOLE.(shortfall_1a, timestampcol_a) .≈
-              LOLE.(shortfall2_1a, timestampcol_a))
-        @test all(EUE.(shortfall_1a, timestampcol_a) .≈
-              EUE.(shortfall2_1a, timestampcol_a))
-        @test all(LOLE.(shortfall_1a, "Region", timestampcol_a) .≈
-              LOLE.(shortfall2_1a, "Region", timestampcol_a))
-        @test all(EUE.(shortfall_1a, "Region", timestampcol_a) .≈
-              EUE.(shortfall2_1a, "Region", timestampcol_a))
+        @test all(LOLE.(shortfall_1a, timestamps_a) .≈
+                  LOLE.(shortfall2_1a, timestamps_a))
+        @test all(EUE.(shortfall_1a, timestamps_a) .≈
+                  EUE.(shortfall2_1a, timestamps_a))
+        @test all(LOLE(shortfall_1a, "Region", :) .≈
+                  LOLE(shortfall2_1a, "Region", :))
+        @test all(EUE(shortfall_1a, "Region", :) .≈
+                  EUE(shortfall2_1a, "Region", :))
 
-        @test all(withinrange.(LOLE.(shortfall_1a, timestampcol_a),
+        @test all(withinrange.(LOLE.(shortfall_1a, timestamps_a),
                                TestSystems.singlenode_a_lolps, nstderr_tol))
-        @test all(withinrange.(EUE.(shortfall_1a, timestampcol_a),
+        @test all(withinrange.(EUE.(shortfall_1a, timestamps_a),
                                TestSystems.singlenode_a_eues, nstderr_tol))
-        @test all(withinrange.(LOLE.(shortfall_1a, "Region", timestampcol_a),
+        @test all(withinrange.(LOLE(shortfall_1a, "Region", :),
                                TestSystems.singlenode_a_lolps, nstderr_tol))
-        @test all(withinrange.(EUE.(shortfall_1a, "Region", timestampcol_a),
+        @test all(withinrange.(EUE(shortfall_1a, "Region", :),
                                TestSystems.singlenode_a_eues, nstderr_tol))
 
         # Single-region system A - 5 min version
@@ -92,22 +98,22 @@
         @test withinrange(EUE(shortfall_1a5, "Region"),
                           TestSystems.singlenode_a_eue/12, nstderr_tol)
 
-        @test all(LOLE.(shortfall_1a5, timestampcol_a5) .≈
-              LOLE.(shortfall2_1a5, timestampcol_a5))
-        @test all(EUE.(shortfall_1a5, timestampcol_a5) .≈
-              EUE.(shortfall2_1a5, timestampcol_a5))
-        @test all(LOLE.(shortfall_1a5, "Region", timestampcol_a5) .≈
-              LOLE.(shortfall2_1a5, "Region", timestampcol_a5))
-        @test all(EUE.(shortfall_1a5, "Region", timestampcol_a5) .≈
-              EUE.(shortfall2_1a5, "Region", timestampcol_a5))
+        @test all(LOLE.(shortfall_1a5, timestamps_a5) .≈
+                  LOLE.(shortfall2_1a5, timestamps_a5))
+        @test all(EUE.(shortfall_1a5, timestamps_a5) .≈
+                  EUE.(shortfall2_1a5, timestamps_a5))
+        @test all(LOLE(shortfall_1a5, "Region", :) .≈
+                  LOLE(shortfall2_1a5, "Region", :))
+        @test all(EUE(shortfall_1a5, "Region", :) .≈
+                  EUE(shortfall2_1a5, "Region", :))
 
-        @test all(withinrange.(LOLE.(shortfall_1a5, timestampcol_a5),
+        @test all(withinrange.(LOLE.(shortfall_1a5, timestamps_a5),
                                TestSystems.singlenode_a_lolps, nstderr_tol))
-        @test all(withinrange.(EUE.(shortfall_1a5, timestampcol_a5),
+        @test all(withinrange.(EUE.(shortfall_1a5, timestamps_a5),
                                TestSystems.singlenode_a_eues ./ 12, nstderr_tol))
-        @test all(withinrange.(LOLE.(shortfall_1a5, "Region", timestampcol_a5),
+        @test all(withinrange.(LOLE(shortfall_1a5, "Region", :),
                                TestSystems.singlenode_a_lolps, nstderr_tol))
-        @test all(withinrange.(EUE.(shortfall_1a5, "Region", timestampcol_a5),
+        @test all(withinrange.(EUE(shortfall_1a5, "Region", :),
                                TestSystems.singlenode_a_eues ./ 12, nstderr_tol))
 
         # Single-region system B
@@ -126,48 +132,46 @@
         @test withinrange(EUE(shortfall_1b, "Region"),
                           TestSystems.singlenode_b_eue, nstderr_tol)
 
-        @test all(LOLE.(shortfall_1b, timestampcol_b) .≈
-              LOLE.(shortfall2_1b, timestampcol_b))
-        @test all(EUE.(shortfall_1b, timestampcol_b) .≈
-              EUE.(shortfall2_1b, timestampcol_b))
-        @test all(LOLE.(shortfall_1b, "Region", timestampcol_b) .≈
-              LOLE.(shortfall2_1b, "Region", timestampcol_b))
-        @test all(EUE.(shortfall_1b, "Region", timestampcol_b) .≈
-              EUE.(shortfall2_1b, "Region", timestampcol_b))
+        @test all(LOLE.(shortfall_1b, timestamps_b) .≈
+                  LOLE.(shortfall2_1b, timestamps_b))
+        @test all(EUE.(shortfall_1b, timestamps_b) .≈
+                  EUE.(shortfall2_1b, timestamps_b))
+        @test all(LOLE(shortfall_1b, "Region", :) .≈
+                  LOLE(shortfall2_1b, "Region", :))
+        @test all(EUE(shortfall_1b, "Region", :) .≈
+                  EUE(shortfall2_1b, "Region", :))
 
-        @test all(withinrange.(LOLE.(shortfall_1b, timestampcol_b),
+        @test all(withinrange.(LOLE.(shortfall_1b, timestamps_b),
                                TestSystems.singlenode_b_lolps, nstderr_tol))
-        @test all(withinrange.(EUE.(shortfall_1b, timestampcol_b),
+        @test all(withinrange.(EUE.(shortfall_1b, timestamps_b),
                                TestSystems.singlenode_b_eues, nstderr_tol))
-        @test all(withinrange.(LOLE.(shortfall_1b, "Region", timestampcol_b),
-                               reshape(TestSystems.singlenode_b_lolps, :, 1), nstderr_tol))
-        @test all(withinrange.(EUE.(shortfall_1b, "Region", timestampcol_b),
-                               reshape(TestSystems.singlenode_b_eues, :, 1), nstderr_tol))
+        @test all(withinrange.(LOLE(shortfall_1b, "Region", :),
+                               TestSystems.singlenode_b_lolps, nstderr_tol))
+        @test all(withinrange.(EUE(shortfall_1b, "Region", :),
+                               TestSystems.singlenode_b_eues, nstderr_tol))
 
         # Three-region system
 
         @test LOLE(shortfall_3) ≈ LOLE(shortfall2_3)
         @test EUE(shortfall_3) ≈ EUE(shortfall2_3)
-        @test all(LOLE.(shortfall_3, regionsrow) .≈ LOLE.(shortfall2_3, regionsrow))
-        @test all(EUE.(shortfall_3, regionsrow) .≈ EUE.(shortfall2_3, regionsrow))
+        @test all(LOLE.(shortfall_3, regionscol) .≈ LOLE.(shortfall2_3, regionscol))
+        @test all(EUE.(shortfall_3, regionscol) .≈ EUE.(shortfall2_3, regionscol))
 
         @test withinrange(LOLE(shortfall_3),
                           TestSystems.threenode_lole, nstderr_tol)
         @test withinrange(EUE(shortfall_3),
                           TestSystems.threenode_eue, nstderr_tol)
-        @test all(withinrange.(LOLE.(shortfall_3, timestampcol_3),
+        @test all(withinrange.(LOLE.(shortfall_3, timestamps_3),
                                TestSystems.threenode_lolps, nstderr_tol))
-        @test all(withinrange.(EUE.(shortfall_3, timestampcol_3),
+        @test all(withinrange.(EUE.(shortfall_3, timestamps_3),
                                TestSystems.threenode_eues, nstderr_tol))
 
-        @test all(LOLE.(shortfall_3, timestampcol_3) .≈
-              LOLE.(shortfall2_3, timestampcol_3))
-        @test all(EUE.(shortfall_3, timestampcol_3) .≈
-              EUE.(shortfall2_3, timestampcol_3))
-        @test all(LOLE.(shortfall_3, regionsrow, timestampcol_3) .≈
-              LOLE.(shortfall2_3, regionsrow, timestampcol_3))
-        @test all(EUE.(shortfall_3, regionsrow, timestampcol_3) .≈
-              EUE.(shortfall2_3, regionsrow, timestampcol_3))
+        @test all(LOLE.(shortfall_3, timestamps_3) .≈
+                  LOLE.(shortfall2_3, timestamps_3))
+        @test all(EUE.(shortfall_3, timestamps_3) .≈
+                  EUE.(shortfall2_3, timestamps_3))
+        @test all(LOLE(shortfall_3, :, :) .≈ LOLE(shortfall2_3, :, :))
+        @test all(EUE(shortfall_3, :, :) .≈ EUE(shortfall2_3, :, :))
 
         @test withinrange(
             LOLE(shortfall_3, "Region C", ZonedDateTime(2018,10,30,1,TestSystems.tz)),
@@ -180,19 +184,16 @@
         # test systems with unique network flow solutions
 
         println("SpatioTemporal LOLPs:")
-        display(
-            vcat(
-                hcat("", regionsrow),
-                hcat(TestSystems.threenode.timestamps,
-                     LOLE.(shortfall_3, regionsrow, timestampcol_3))
+
+        display(vcat(
+            hcat("", timestamprow_3),
+            hcat(regionscol, LOLE(shortfall_3, :, :))
         )); println()
 
         println("SpatioTemporal EUEs:")
-        display(
-            vcat(
-                hcat("", regionsrow),
-                hcat(TestSystems.threenode.timestamps,
-                     EUE.(shortfall_3, regionsrow, timestampcol_3))
+        display(vcat(
+            hcat("", timestamprow_3),
+            hcat(regionscol, EUE(shortfall_3, :, :))
         )); println()
 
     end
@@ -222,33 +223,23 @@
 
         # Three-region system
 
-        interfacesrow = reshape(flow_3.interfaces, 1, :)
-
         println("Network Flows:")
-        display(
-            vcat(
-                hcat("", interfacesrow),
-                hcat(timestampcol_3,
-                     getindex.(flow_3, interfacesrow, timestampcol_3))
+        display(vcat(
+            hcat("", timestamprow_3),
+            hcat(flow_3.interfaces, flow_3[:, :])
         )); println()
 
-        @test all(getindex.(flow_3, interfacesrow) .≈
-                  getindex.(flow2_3, interfacesrow))
-        @test all(getindex.(flow_3, interfacesrow, timestampcol_3) .≈
-                  getindex.(flow2_3, interfacesrow, timestampcol_3))
+        @test all(flow_3[:] .≈ flow2_3[:])
+        @test all(flow_3[:, :] .≈ flow2_3[:, :])
 
         println("Network Utilizations:")
-        display(
-            vcat(
-                hcat("", interfacesrow),
-                hcat(timestampcol_3,
-                     getindex.(util_3, interfacesrow, timestampcol_3))
+        display(vcat(
+            hcat("", timestamprow_3),
+            hcat(flow_3.interfaces, util_3[:, :])
         )); println()
 
-        @test all(getindex.(util_3, interfacesrow) .≈
-                  getindex.(util2_3, interfacesrow))
-        @test all(getindex.(util_3, interfacesrow, timestampcol_3) .≈
-                  getindex.(util2_3, interfacesrow, timestampcol_3))
+        @test all(util_3[:] .≈ util2_3[:])
+        @test all(util_3[:, :] .≈ util2_3[:, :])
 
     end
 


### PR DESCRIPTION
Allow selection of all time periods / resources in a dimension by providing `:`, instead of requiring the use to come up with a list of all possible values.