### PR TITLE
Stop using rpad with null bytes for Julia 1.7 compatibility

### DIFF
--- a/src/PRASBase/write.jl
+++ b/src/PRASBase/write.jl
@@ -304,5 +304,15 @@ function string_table!(
 
 end
 
-convertstring(s::AbstractString, strlen::Int) =
-    Vector{Char}.(rpad(ascii(s), strlen, '\0')[1:strlen])
+function convertstring(s::AbstractString, strlen::Int)
+
+    oldstring = ascii(s)
+    newstring = fill('\0', strlen)
+
+    for i in 1:min(strlen, length(s))
+        newstring[i] = oldstring[i]
+    end
+
+    return newstring
+
+end


### PR DESCRIPTION
`rpad` in Julia 1.7 works with `textwidth` instead of `length`, and so errors when it gets a zero-textwidth `'\0'` padding value. This switches to manually allocating and copying over characters instead.