### PR TITLE
Fix bug in SurplusSamples result collection

### DIFF
--- a/src/ResourceAdequacy/simulations/sequentialmontecarlo/result_surplus.jl
+++ b/src/ResourceAdequacy/simulations/sequentialmontecarlo/result_surplus.jl
@@ -133,9 +133,11 @@ function record!(
     sampleid::Int, t::Int
 ) where {N,L,T,P,E}
 
+    edges = problem.fp.edges
+
     for (r, e) in enumerate(problem.region_unused_edges)
 
-        regionsurplus = problem.fp.edges[e].flow
+        regionsurplus = edges[e].flow
 
         for s in system.region_stor_idxs[r]
             se_idx = problem.storage_dischargeunused_edges[s]


### PR DESCRIPTION
Fixes an error in the `SurplusSamples` result spec code. This highlights a broader issue with a lack of automated tests on the sample-level results, which should be fixed independent of this.