### PR TITLE
Updating minimum supported Julia version to 1.6

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - "1.3"  # Min supported
+          - "1.6"  # Min supported
           - "1"    # Latest Release
         os:
           - ubuntu-latest

--- a/Project.toml
+++ b/Project.toml
@@ -20,7 +20,7 @@ TimeZones = "f269a46b-ccf7-5d73-abea-4c690281aa53"
 
 [compat]
 HDF5 = "0.16"
-julia = "1.10.2"
+julia = "1.6"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/Project.toml
+++ b/Project.toml
@@ -20,7 +20,7 @@ TimeZones = "f269a46b-ccf7-5d73-abea-4c690281aa53"
 
 [compat]
 HDF5 = "0.16"
-julia = "1.3"
+julia = "1.10.2"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
As the CI's are failing in Julia v1.3, the Project.toml and the CI version should now be requiring Julia v1.6 at minimum. At the 1.6 version, all the CI tests should pass.