### PR TITLE
Memory footprint reduction

### DIFF
--- a/src/PRASBase/assets.jl
+++ b/src/PRASBase/assets.jl
@@ -21,12 +21,12 @@ struct Generators{N,L,T<:Period,P<:PowerUnit} <: AbstractAssets{N,L,T,P}
         @assert allunique(names)
 
         @assert size(capacity) == (n_gens, N)
-        @assert all(capacity .>= 0) # Why not just use unsigned integers?
+        @assert all(isnonnegative, capacity) # Why not just use unsigned integers?
 
         @assert size(λ) == (n_gens, N)
         @assert size(μ) == (n_gens, N)
-        @assert all(0 .<= λ .<= 1)
-        @assert all(0 .<= μ .<= 1)
+        @assert all(isfractional, λ)
+        @assert all(isfractional, μ)
 
         new{N,L,T,P}(string.(names), string.(categories), capacity, λ, μ)
 
@@ -109,21 +109,21 @@ struct Storages{N,L,T<:Period,P<:PowerUnit,E<:EnergyUnit} <: AbstractAssets{N,L,
         @assert size(chargecapacity) == (n_stors, N)
         @assert size(dischargecapacity) == (n_stors, N)
         @assert size(energycapacity) == (n_stors, N)
-        @assert all(chargecapacity .>= 0)
-        @assert all(dischargecapacity .>= 0)
-        @assert all(energycapacity .>= 0)
+        @assert all(isnonnegative, chargecapacity)
+        @assert all(isnonnegative, dischargecapacity)
+        @assert all(isnonnegative, energycapacity)
 
         @assert size(chargeefficiency) == (n_stors, N)
         @assert size(dischargeefficiency) == (n_stors, N)
         @assert size(carryoverefficiency) == (n_stors, N)
-        @assert all(0 .< chargeefficiency .<= 1)
-        @assert all(0 .< dischargeefficiency .<= 1)
-        @assert all(0 .< carryoverefficiency .<= 1)
+        @assert all(isfractional, chargeefficiency)
+        @assert all(isfractional, dischargeefficiency)
+        @assert all(isfractional, carryoverefficiency)
 
         @assert size(λ) == (n_stors, N)
         @assert size(μ) == (n_stors, N)
-        @assert all(0 .<= λ .<= 1)
-        @assert all(0 .<= μ .<= 1)
+        @assert all(isfractional, λ)
+        @assert all(isfractional, μ)
 
         new{N,L,T,P,E}(string.(names), string.(categories),
                        chargecapacity, dischargecapacity, energycapacity,
@@ -239,30 +239,30 @@ struct GeneratorStorages{N,L,T<:Period,P<:PowerUnit,E<:EnergyUnit} <: AbstractAs
         @assert size(discharge_capacity) == (n_stors, N)
         @assert size(energy_capacity) == (n_stors, N)
 
-        @assert all(charge_capacity .>= 0)
-        @assert all(discharge_capacity .>= 0)
-        @assert all(energy_capacity .>= 0)
+        @assert all(isnonnegative, charge_capacity)
+        @assert all(isnonnegative, discharge_capacity)
+        @assert all(isnonnegative, energy_capacity)
 
         @assert size(charge_efficiency) == (n_stors, N)
         @assert size(discharge_efficiency) == (n_stors, N)
         @assert size(carryover_efficiency) == (n_stors, N)
 
-        @assert all(0 .< charge_efficiency .<= 1)
-        @assert all(0 .< discharge_efficiency .<= 1)
-        @assert all(0 .< carryover_efficiency .<= 1)
+        @assert all(isfractional, charge_efficiency)
+        @assert all(isfractional, discharge_efficiency)
+        @assert all(isfractional, carryover_efficiency)
 
         @assert size(inflow) == (n_stors, N)
         @assert size(gridwithdrawal_capacity) == (n_stors, N)
         @assert size(gridinjection_capacity) == (n_stors, N)
 
-        @assert all(inflow .>= 0)
-        @assert all(gridwithdrawal_capacity .>= 0)
-        @assert all(gridinjection_capacity .>= 0)
+        @assert all(isnonnegative, inflow)
+        @assert all(isnonnegative, gridwithdrawal_capacity)
+        @assert all(isnonnegative, gridinjection_capacity)
 
         @assert size(λ) == (n_stors, N)
         @assert size(μ) == (n_stors, N)
-        @assert all(0 .<= λ .<= 1)
-        @assert all(0 .<= μ .<= 1)
+        @assert all(isfractional, λ)
+        @assert all(isfractional, μ)
 
         new{N,L,T,P,E}(
             string.(names), string.(categories),
@@ -377,13 +377,13 @@ struct Lines{N,L,T<:Period,P<:PowerUnit} <: AbstractAssets{N,L,T,P}
 
         @assert size(forward_capacity) == (n_lines, N)
         @assert size(backward_capacity) == (n_lines, N)
-        @assert all(forward_capacity .>= 0)
-        @assert all(backward_capacity .>= 0)
+        @assert all(isnonnegative, forward_capacity)
+        @assert all(isnonnegative, backward_capacity)
 
         @assert size(λ) == (n_lines, N)
         @assert size(μ) == (n_lines, N)
-        @assert all(0 .<= λ .<= 1)
-        @assert all(0 .<= μ .<= 1)
+        @assert all(isfractional, λ)
+        @assert all(isfractional, μ)
 
         new{N,L,T,P}(string.(names), string.(categories), forward_capacity, backward_capacity, λ, μ)
 

--- a/src/PRASBase/collections.jl
+++ b/src/PRASBase/collections.jl
@@ -10,7 +10,7 @@ struct Regions{N,P<:PowerUnit}
         n_regions = length(names)
 
         @assert size(load) == (n_regions, N)
-        @assert all(load .>= 0)
+        @assert all(isnonnegative, load)
 
         new{N,P}(string.(names), load)
 
@@ -41,8 +41,8 @@ struct Interfaces{N,P<:PowerUnit}
 
         @assert size(forwardcapacity) == (n_interfaces, N)
         @assert size(backwardcapacity) == (n_interfaces, N)
-        @assert all(forwardcapacity .>= 0)
-        @assert all(backwardcapacity .>= 0)
+        @assert all(isnonnegative, forwardcapacity)
+        @assert all(isnonnegative, backwardcapacity)
 
         new{N,P}(regions_from, regions_to, forwardcapacity, backwardcapacity)
 

--- a/src/PRASBase/read.jl
+++ b/src/PRASBase/read.jl
@@ -76,9 +76,9 @@ function systemmodel_0_5(f::File)
 
         generators = Generators{N,L,T,P}(
             gen_names[region_order], gen_categories[region_order],
-            Int.(read(f["generators/capacity"]))[region_order, :],
-            read(f["generators/failureprobability"])[region_order, :],
-            read(f["generators/repairprobability"])[region_order, :]
+            load_matrix(f["generators/capacity"], region_order, Int),
+            load_matrix(f["generators/failureprobability"], region_order, Float64),
+            load_matrix(f["generators/repairprobability"], region_order, Float64)
         )
 
         region_gen_idxs = makeidxlist(gen_regions[region_order], n_regions)
@@ -104,14 +104,14 @@ function systemmodel_0_5(f::File)
 
         storages = Storages{N,L,T,P,E}(
             stor_names[region_order], stor_categories[region_order],
-            Int.(read(f["storages/chargecapacity"]))[region_order, :],
-            Int.(read(f["storages/dischargecapacity"]))[region_order, :],
-            Int.(read(f["storages/energycapacity"]))[region_order, :],
-            read(f["storages/chargeefficiency"])[region_order, :],
-            read(f["storages/dischargeefficiency"])[region_order, :],
-            read(f["storages/carryoverefficiency"])[region_order, :],
-            read(f["storages/failureprobability"])[region_order, :],
-            read(f["storages/repairprobability"])[region_order, :]
+            load_matrix(f["storages/chargecapacity"], region_order, Int),
+            load_matrix(f["storages/dischargecapacity"], region_order, Int),
+            load_matrix(f["storages/energycapacity"], region_order, Int),
+            load_matrix(f["storages/chargeefficiency"], region_order, Float64),
+            load_matrix(f["storages/dischargeefficiency"], region_order, Float64),
+            load_matrix(f["storages/carryoverefficiency"], region_order, Float64),
+            load_matrix(f["storages/failureprobability"], region_order, Float64),
+            load_matrix(f["storages/repairprobability"], region_order, Float64)
         )
 
         region_stor_idxs = makeidxlist(stor_regions[region_order], n_regions)
@@ -140,17 +140,18 @@ function systemmodel_0_5(f::File)
 
         generatorstorages = GeneratorStorages{N,L,T,P,E}(
             genstor_names[region_order], genstor_categories[region_order],
-            Int.(read(f["generatorstorages/chargecapacity"]))[region_order, :],
-            Int.(read(f["generatorstorages/dischargecapacity"]))[region_order, :],
-            Int.(read(f["generatorstorages/energycapacity"]))[region_order, :],
-            read(f["generatorstorages/chargeefficiency"])[region_order, :],
-            read(f["generatorstorages/dischargeefficiency"])[region_order, :],
-            read(f["generatorstorages/carryoverefficiency"])[region_order, :],
-            Int.(read(f["generatorstorages/inflow"]))[region_order, :],
-            Int.(read(f["generatorstorages/gridwithdrawalcapacity"]))[region_order, :],
-            Int.(read(f["generatorstorages/gridinjectioncapacity"]))[region_order, :],
-            read(f["generatorstorages/failureprobability"])[region_order, :],
-            read(f["generatorstorages/repairprobability"])[region_order, :])
+            load_matrix(f["generatorstorages/chargecapacity"], region_order, Int),
+            load_matrix(f["generatorstorages/dischargecapacity"], region_order, Int),
+            load_matrix(f["generatorstorages/energycapacity"], region_order, Int),
+            load_matrix(f["generatorstorages/chargeefficiency"], region_order, Float64),
+            load_matrix(f["generatorstorages/dischargeefficiency"], region_order, Float64),
+            load_matrix(f["generatorstorages/carryoverefficiency"], region_order, Float64),
+            load_matrix(f["generatorstorages/inflow"], region_order, Int),
+            load_matrix(f["generatorstorages/gridwithdrawalcapacity"], region_order, Int),
+            load_matrix(f["generatorstorages/gridinjectioncapacity"], region_order, Int),
+            load_matrix(f["generatorstorages/failureprobability"], region_order, Float64),
+            load_matrix(f["generatorstorages/repairprobability"], region_order, Float64)
+        )
 
         region_genstor_idxs = makeidxlist(genstor_regions[region_order], n_regions)
 
@@ -235,8 +236,9 @@ function systemmodel_0_5(f::File)
             line_names[interface_order], line_categories[interface_order],
             line_forwardcapacity[interface_order, :],
             line_backwardcapacity[interface_order, :],
-            read(f["lines/failureprobability"])[interface_order, :],
-            read(f["lines/repairprobability"])[interface_order, :])
+            load_matrix(f["lines/failureprobability"], interface_order, Float64),
+            load_matrix(f["lines/repairprobability"], interface_order, Float64)
+        )
 
         interface_line_idxs = makeidxlist(line_interfaces[interface_order], n_interfaces)
 

--- a/src/PRASBase/utils.jl
+++ b/src/PRASBase/utils.jl
@@ -28,3 +28,6 @@ function makeidxlist(collectionidxs::Vector{Int}, n_collections::Int)
     return idxlist
 
 end
+
+isnonnegative(x::Real) = x >= 0
+isfractional(x::Real) = 0 <= x <= 1

--- a/src/PRASBase/utils.jl
+++ b/src/PRASBase/utils.jl
@@ -31,3 +31,26 @@ end
 
 isnonnegative(x::Real) = x >= 0
 isfractional(x::Real) = 0 <= x <= 1
+
+function load_matrix(data::HDF5.Dataset, roworder::Vector{Int}, T::DataType)
+
+    result = read(data)
+
+    if roworder != 1:size(result, 1)
+        @warn("HDF5 data is ordered differently from in-memory requirements. " *
+              "Data will be reordered, but this may temporarily " *
+              "consume large amounts of memory.")
+        # TODO: More memory-efficient approaches are possible
+        result = result[roworder, :]
+    end
+
+    if eltype(result) != T
+        @warn("HDF5 data is typed differently from in-memory requirements. " *
+              "Data conversion will be attempted, but this may temporarily " *
+              "consume large amounts of memory.")
+        result = T.(result)
+    end
+
+    return result
+
+end

--- a/src/ResourceAdequacy/simulations/sequentialmontecarlo/result_shortfall.jl
+++ b/src/ResourceAdequacy/simulations/sequentialmontecarlo/result_shortfall.jl
@@ -159,15 +159,21 @@ function finalize(
         mean_std(acc.unservedload_regionperiod)
 
     nsamples = first(acc.unservedload_total.stats).n
+
     p2e = conversionfactor(L,T,P,E)
+    ue_regionperiod_mean .*= p2e
+    ue_total_std *= p2e
+    ue_region_std .*= p2e
+    ue_period_std .*= p2e
+    ue_regionperiod_std .*= p2e
 
     return ShortfallResult{N,L,T,E}(
         nsamples, system.regions.names, system.timestamps,
         ep_total_mean, ep_total_std, ep_region_mean, ep_region_std,
         ep_period_mean, ep_period_std,
         ep_regionperiod_mean, ep_regionperiod_std,
-        p2e*ue_regionperiod_mean, p2e*ue_total_std,
-        p2e*ue_region_std, p2e*ue_period_std, p2e*ue_regionperiod_std)
+        ue_regionperiod_mean, ue_total_std,
+        ue_region_std, ue_period_std, ue_regionperiod_std)
 
 end
 


### PR DESCRIPTION
Eliminates, or skips when not needed, certain memory allocations which previously caused noticeable memory usage when loading very large systems (tens of thousands of units and many years of hourly data).

If assets need to be reordered when loading from disk, a (potentially very large) copy of the asset's data will still be made. In theory this could be eliminated and the data matrices rearranged in-place. However, such reordering isn't needed if the assets are correctly ordered on disk, which they should be if the system was written to disk using `savemodel`, so that optimization isn't implemented here.