### PR TITLE
Add doc-strings to resource adequacy functions

### DIFF
--- a/src/PRASBase/SystemModel.jl
+++ b/src/PRASBase/SystemModel.jl
@@ -1,7 +1,19 @@
-struct SystemModel{N,L,T<:Period,P<:PowerUnit,E<:EnergyUnit}
+"""
+    SystemModel
 
-    regions::Regions{N,P}
-    interfaces::Interfaces{N,P}
+SystemModel is the primary data structure for Probabilistic Resource Adequacy Studies (PRAS).
+
+You can also load a `SystemModel` from an appropriately-formatted HDF5 file on disk.
+
+# Examples
+
+```julia
+pras = SystemModel("path/to/pras.pras")
+```
+"""
+struct SystemModel{N, L, T <: Period, P <: PowerUnit, E <: EnergyUnit}
+    regions::Regions{N, P}
+    interfaces::Interfaces{N, P}
 
     generators::Generators{N,L,T,P}
     region_gen_idxs::Vector{UnitRange{Int}}

--- a/src/PRASBase/read.jl
+++ b/src/PRASBase/read.jl
@@ -1,9 +1,3 @@
-"""
-
-    SystemModel(filename::String)
-
-Load a `SystemModel` from an appropriately-formatted HDF5 file on disk.
-"""
 function SystemModel(inputfile::String)
 
     system = h5open(inputfile, "r") do f::File

--- a/src/ResourceAdequacy/metrics.jl
+++ b/src/ResourceAdequacy/metrics.jl
@@ -63,10 +63,12 @@ end
 Base.isapprox(x::ReliabilityMetric, y::ReliabilityMetric) =
         isapprox(val(x), val(y)) && isapprox(stderror(x), stderror(y))
 
-# Loss-of-Load Expectation
+"""
+    LOLE
 
-struct LOLE{N,L,T<:Period} <: ReliabilityMetric
-
+Loss of load expectation metric. Contains a mean and standard error estimate.
+"""
+struct LOLE{N, L, T <: Period} <: ReliabilityMetric
     lole::MeanEstimate
 
     function LOLE{N,L,T}(lole::MeanEstimate) where {N,L,T<:Period}
@@ -89,8 +91,11 @@ function Base.show(io::IO, x::LOLE{N,L,T}) where {N,L,T}
 
 end
 
-# Expected Unserved Energy
+"""
+    EUE
 
+Expected unserved energy expectation metric. Contains a mean and standard error estimate.
+"""
 struct EUE{N,L,T<:Period,E<:EnergyUnit} <: ReliabilityMetric
 
     eue::MeanEstimate

--- a/src/ResourceAdequacy/results/availability.jl
+++ b/src/ResourceAdequacy/results/availability.jl
@@ -11,8 +11,14 @@ getindex(x::AbstractAvailabilityResult, name::String, ::Colon) =
 getindex(x::AbstractAvailabilityResult, ::Colon, ::Colon) =
     getindex.(x, names(x), permutedims(x.timestamps))
 
-# Full Generator availability data
+"""
+    GeneratorAvailability
 
+Generator availability represents the availability of generators at timestamps
+in a GeneratorAvailabilityResult with a (generators, timestamps, samples) matrix API.
+
+No averaging occurs.
+"""
 struct GeneratorAvailability <: ResultSpec end
 
 struct GeneratorAvailabilityResult{N,L,T<:Period} <: AbstractAvailabilityResult{N,L,T}
@@ -32,8 +38,14 @@ function getindex(x::GeneratorAvailabilityResult, g::AbstractString, t::ZonedDat
     return vec(x.available[i_g, i_t, :])
 end
 
-# Full Storage availability data
+"""
+    StorageAvailability
 
+Storage availability represents the availability of storage resources at timestamps
+in a StorageAvailabilityResult with a (storages, timestamps, samples) matrix API.
+
+No averaging occurs.
+"""
 struct StorageAvailability <: ResultSpec end
 
 struct StorageAvailabilityResult{N,L,T<:Period} <: AbstractAvailabilityResult{N,L,T}
@@ -53,8 +65,14 @@ function getindex(x::StorageAvailabilityResult, s::AbstractString, t::ZonedDateT
     return vec(x.available[i_s, i_t, :])
 end
 
-# Full GeneratorStorage availability data
+"""
+    GeneratorStorageAvailability
 
+Generator storage availability represents the availability of generatorstorage resources at timestamps
+in a GeneratorStorageAvailabilityResult with a (generatorstorages, timestamps, samples) matrix API.
+
+No averaging occurs
+"""
 struct GeneratorStorageAvailability <: ResultSpec end
 
 struct GeneratorStorageAvailabilityResult{N,L,T<:Period} <: AbstractAvailabilityResult{N,L,T}
@@ -74,8 +92,14 @@ function getindex(x::GeneratorStorageAvailabilityResult, gs::AbstractString, t::
     return vec(x.available[i_gs, i_t, :])
 end
 
-# Full Line availability data
+"""
+    LineAvailability
 
+Line availability represents the availability of lines at timestamps
+in a LineAvailabilityResult with a (lines, timestamps, samples) matrix API.
+
+No averaging occurs.
+"""
 struct LineAvailability <: ResultSpec end
 
 struct LineAvailabilityResult{N,L,T<:Period} <: AbstractAvailabilityResult{N,L,T}

--- a/src/ResourceAdequacy/results/energy.jl
+++ b/src/ResourceAdequacy/results/energy.jl
@@ -16,6 +16,19 @@ getindex(x::AbstractEnergyResult, ::Colon, ::Colon) =
 
 # Sample-averaged Storage state-of-charge data
 
+"""
+    StorageEnergy
+
+Storage energy represents the state-of-charge of storage
+resources at timestamps in a StorageEnergyResult with a (storages, timestamps)
+matrix API.
+
+Separate samples are averaged together into mean and std values.
+
+See [`StorageEnergySamples`](@ref) for all storage energy samples.
+
+See [`GeneratorStorageEnergy`](@ref) for generator storage energy.
+"""
 struct StorageEnergy <: ResultSpec end
 
 struct StorageEnergyResult{N,L,T<:Period,E<:EnergyUnit} <: AbstractEnergyResult{N,L,T}
@@ -45,7 +58,19 @@ function getindex(x::StorageEnergyResult, s::AbstractString, t::ZonedDateTime)
 end
 
 # Sample-averaged GeneratorStorage state-of-charge data
+"""
+    GeneratorStorageEnergy
 
+Generator storage energy represents state-of-charge of generatorstorage
+resources at timestamps in a StorageEnergyResult with a (generatorstorages, timestamps)
+matrix API.
+
+Separate samples are averaged together into mean and std values.
+
+See [`GeneratorStorageEnergySamples`](@ref) for all generator storage energy samples.
+
+See [`StorageEnergy`](@ref) for storage energy.
+"""
 struct GeneratorStorageEnergy <: ResultSpec end
 
 struct GeneratorStorageEnergyResult{N,L,T<:Period,E<:EnergyUnit} <: AbstractEnergyResult{N,L,T}
@@ -74,8 +99,15 @@ function getindex(x::GeneratorStorageEnergyResult, gs::AbstractString, t::ZonedD
     return x.energy_mean[i_gs, i_t], x.energy_regionperiod_std[i_gs, i_t]
 end
 
-# Full Storage state-of-charge data
+"""
+    StorageEnergySamples
 
+Storage energy samples represent the state-of-charge of storage
+resources at timestamps, which has not been averaged across different samples.
+This presents a 3D matrix API (storages, timestamps, samples).
+
+See [`StorageEnergy`](@ref) for sample-averaged storage energy.
+"""
 struct StorageEnergySamples <: ResultSpec end
 
 struct StorageEnergySamplesResult{N,L,T<:Period,E<:EnergyUnit} <: AbstractEnergyResult{N,L,T}
@@ -100,8 +132,15 @@ function getindex(x::StorageEnergySamplesResult, s::AbstractString, t::ZonedDate
     return vec(x.energy[i_s, i_t, :])
 end
 
-# Full GeneratorStorage state-of-charge data
+"""
+    GeneratorStorageEnergySamples
 
+Generator storage energy samples represent the state-of-charge of generatorstorage
+resources at timestamps, which has not been averaged across different samples.
+This presents a 3D matrix API (generatorstorages, timestamps, samples).
+
+See [`GeneratorStorageEnergy`](@ref) for sample-averaged generator storage energy.
+"""
 struct GeneratorStorageEnergySamples <: ResultSpec end
 
 struct GeneratorStorageEnergySamplesResult{N,L,T<:Period,E<:EnergyUnit} <: AbstractEnergyResult{N,L,T}

--- a/src/ResourceAdequacy/results/flow.jl
+++ b/src/ResourceAdequacy/results/flow.jl
@@ -1,3 +1,13 @@
+"""
+    Flow
+
+Flow metric represents the flow between interfaces at timestamps
+in a FlowResult with a (interfaces, timestamps) matrix API.
+
+Separate samples are averaged together into mean and std values.
+
+See [`FlowSamples`](@ref) for all flow samples.
+"""
 struct Flow <: ResultSpec end
 abstract type AbstractFlowResult{N,L,T} <: Result{N,L,T} end
 
@@ -44,7 +54,15 @@ function getindex(x::FlowResult, i::Pair{<:AbstractString,<:AbstractString}, t::
 end
 
 # Full flow data
+"""
+    FlowSamples
 
+Flow samples represent the flow between interfaces at timestamps, which has
+not been averaged across different samples. This presents a
+3D matrix API (interfaces, timestamps, samples).
+
+See [`Flow`](@ref) for sample-averaged flow data.
+"""
 struct FlowSamples <: ResultSpec end
 
 struct FlowSamplesResult{N,L,T<:Period,P<:PowerUnit} <: AbstractFlowResult{N,L,T}

--- a/src/ResourceAdequacy/results/shortfall.jl
+++ b/src/ResourceAdequacy/results/shortfall.jl
@@ -1,3 +1,14 @@
+
+"""
+    Shortfall
+
+Shortfall metric represents lost load at regions and timesteps
+in ShortfallResult with a (regions, timestamps) matrix API.
+
+Separate samples are averaged together into mean and std values.
+
+See [`ShortfallSamples`](@ref) for all shortfall samples.
+"""
 struct Shortfall <: ResultSpec end
 abstract type AbstractShortfallResult{N,L,T} <: Result{N,L,T} end
 
@@ -34,9 +45,14 @@ EUE(x::AbstractShortfallResult, ::Colon, ::Colon) =
 
 # Sample-averaged shortfall data
 
-struct ShortfallResult{N,L,T<:Period,E<:EnergyUnit} <: AbstractShortfallResult{N,L,T}
+"""
+    ShortfallResult
 
-    nsamples::Union{Int,Nothing}
+Matrix-like data structure for storing shortfall means
+"""
+struct ShortfallResult{N, L, T <: Period, E <: EnergyUnit} <:
+       AbstractShortfallResult{N, L, T}
+    nsamples::Union{Int, Nothing}
     regions::Vector{String}
     timestamps::StepRange{ZonedDateTime,T}
 
@@ -173,8 +189,14 @@ EUE(x::ShortfallResult{N,L,T,E}, t::ZonedDateTime) where {N,L,T,E} =
 EUE(x::ShortfallResult{N,L,T,E}, r::AbstractString, t::ZonedDateTime) where {N,L,T,E} =
     EUE{1,L,T,E}(MeanEstimate(x[r, t]..., x.nsamples))
 
-# Full shortfall data 
+"""
+    ShortfallSamples
 
+ShortfallSamples metric represents lost load at regions and timesteps
+in ShortfallSamplesResult with a (regions, timestamps, samples) matrix API.
+
+See [`Shortfall`](@ref) for averaged shortfall samples.
+"""
 struct ShortfallSamples <: ResultSpec end
 
 struct ShortfallSamplesResult{N,L,T<:Period,P<:PowerUnit,E<:EnergyUnit} <: AbstractShortfallResult{N,L,T}

--- a/src/ResourceAdequacy/results/surplus.jl
+++ b/src/ResourceAdequacy/results/surplus.jl
@@ -1,3 +1,13 @@
+"""
+    Surplus
+
+Surplus metric represents extra generation at regions and timestamps
+in a SurplusResults with a (regions, timestamps) matrix API.
+
+Separate samples are averaged together into mean and std values.
+
+See [`SurplusSamples`](@ref) for all surplus samples.
+"""
 struct Surplus <: ResultSpec end
 abstract type AbstractSurplusResult{N,L,T} <: Result{N,L,T} end
 
@@ -42,7 +52,14 @@ function getindex(x::SurplusResult, r::AbstractString, t::ZonedDateTime)
 end
 
 # Full surplus data 
+"""
+    SurplusSamples
 
+Surplus samples represent extra generation at regions and timestamps
+in a SurplusSamplesResult with a (regions, timestamps, samples) matrix API.
+
+See [`Surplus`](@ref) for sample-averaged surplus data.
+"""
 struct SurplusSamples <: ResultSpec end
 
 struct SurplusSamplesResult{N,L,T<:Period,P<:PowerUnit} <: AbstractSurplusResult{N,L,T}

--- a/src/ResourceAdequacy/results/utilization.jl
+++ b/src/ResourceAdequacy/results/utilization.jl
@@ -1,3 +1,13 @@
+"""
+    Utilization
+
+Utilization metric represents how much an interface between regions is used
+across timestamps in a UtilizationResult with a (interfaces, timestamps) matrix API.
+
+Separate samples are averaged together into mean and std values.
+
+See [`UtilizationSamples`](@ref) for all utilization samples.
+"""
 struct Utilization <: ResultSpec end
 abstract type AbstractUtilizationResult{N,L,T} <: Result{N,L,T} end
 
@@ -41,8 +51,15 @@ function getindex(x::UtilizationResult, i::Pair{<:AbstractString,<:AbstractStrin
     return x.utilization_mean[i_i, i_t], x.utilization_interfaceperiod_std[i_i, i_t]
 end
 
-# Full utilization data
+"""
+    UtilizationSamples
 
+Utilization samples represent the utilization between interfaces at timestamps, which has
+not been averaged across different samples. This presents a
+3D matrix API (interfaces, timestamps, samples).
+
+See [`Utilization`](@ref) for averaged utilization samples.
+"""
 struct UtilizationSamples <: ResultSpec end
 
 struct UtilizationSamplesResult{N,L,T<:Period} <: AbstractUtilizationResult{N,L,T}

--- a/src/ResourceAdequacy/simulations/sequentialmontecarlo/DispatchProblem.jl
+++ b/src/ResourceAdequacy/simulations/sequentialmontecarlo/DispatchProblem.jl
@@ -1,5 +1,4 @@
 """
-
     DispatchProblem(sys::SystemModel)
 
 Create a min-cost flow problem for the multi-region max power delivery problem
@@ -68,7 +67,6 @@ Edges are ordered as:
  14. GenerationStorage charge from inflow (GeneratorStorage order)
  15. GenerationStorage charge unused (GeneratorStorage order)
  16. GenerationStorage inflow unused (GeneratorStorage order)
-
 """
 struct DispatchProblem
 

--- a/src/ResourceAdequacy/simulations/sequentialmontecarlo/SequentialMonteCarlo.jl
+++ b/src/ResourceAdequacy/simulations/sequentialmontecarlo/SequentialMonteCarlo.jl
@@ -2,6 +2,29 @@ include("SystemState.jl")
 include("DispatchProblem.jl")
 include("utils.jl")
 
+"""
+    SequentialMonteCarlo(;
+        samples::Int=10_000,
+        seed::Integer=rand(UInt64),
+        verbose::Bool=false,
+        threaded::Bool=true
+    )
+
+Sequential Monte Carlo simulation parameters for PRAS analysis
+
+It it recommended that you fix the random seed for reproducibility.
+
+# Arguments
+
+  - `samples::Int=10_000`: Number of samples
+  - `seed::Integer=rand(UInt64)`: Random seed
+  - `verbose::Bool=false`: Print progress
+  - `threaded::Bool=true`: Use multi-threading
+
+# Returns
+
+  - `SequentialMonteCarlo`: PRAS analysis method
+"""
 struct SequentialMonteCarlo <: SimulationSpec
 
     nsamples::Int
@@ -17,9 +40,24 @@ struct SequentialMonteCarlo <: SimulationSpec
         seed < 0 && throw(DomainError("Random seed must be non-negative"))
         new(samples, UInt64(seed), verbose, threaded)
     end
-
 end
 
+"""
+    assess(system::SystemModel, method::SequentialMonteCarlo, resultspecs::ResultSpec...)
+
+Run a Sequential Monte Carlo simulation on a `system` using the `method` data
+and return `resultspecs`.
+
+# Arguments
+
+  - `system::SystemModel`: PRAS data structure
+  - `method::SequentialMonteCarlo`: method for PRAS analysis
+  - `resultspecs::ResultSpec...`: PRAS metric for metrics like [`Shortfall`](@ref) missing generation
+
+# Returns
+
+  - `results::Tuple{Vararg{ResultAccumulator{SequentialMonteCarlo}}}`: PRAS metric results
+"""
 function assess(
     system::SystemModel,
     method::SequentialMonteCarlo,


### PR DESCRIPTION
I've moved the doc-string from a file to the struct, since looking at the source in the docs is more valuable.

I haven't checked how these changes appear in PRAS's docs instead of just PRASInterface.jl's.