### PR TITLE
Dsc/results and metrics updates

### DIFF
--- a/PRAS.jl/test/runtests.jl
+++ b/PRAS.jl/test/runtests.jl
@@ -7,6 +7,9 @@ sf, = assess(sys, SequentialMonteCarlo(samples=100), Shortfall())
 
 eue = EUE(sf)
 lole = LOLE(sf)
+neue = NEUE(sf)
 
 @test val(eue) isa Float64
 @test stderror(eue) isa Float64
+@test val(neue) isa Float64
+@test stderror(neue) isa Float64

--- a/PRASCore.jl/src/Results/Results.jl
+++ b/PRASCore.jl/src/Results/Results.jl
@@ -52,29 +52,29 @@ getindex(x::AbstractShortfallResult, ::Colon, ::Colon) =
 
 
 LOLE(x::AbstractShortfallResult, ::Colon, t::ZonedDateTime) =
-    LOLE.(x, x.regions, t)
+    LOLE.(x, x.regions.names, t)
 
 LOLE(x::AbstractShortfallResult, r::AbstractString, ::Colon) =
     LOLE.(x, r, x.timestamps)
 
 LOLE(x::AbstractShortfallResult, ::Colon, ::Colon) =
-    LOLE.(x, x.regions, permutedims(x.timestamps))
+    LOLE.(x, x.regions.names, permutedims(x.timestamps))
 
 
 EUE(x::AbstractShortfallResult, ::Colon, t::ZonedDateTime) =
-    EUE.(x, x.regions, t)
+    EUE.(x, x.regions.names, t)
 
 EUE(x::AbstractShortfallResult, r::AbstractString, ::Colon) =
     EUE.(x, r, x.timestamps)
 
 EUE(x::AbstractShortfallResult, ::Colon, ::Colon) =
-    EUE.(x, x.regions, permutedims(x.timestamps))
+    EUE.(x, x.regions.names, permutedims(x.timestamps))
 
 NEUE(x::AbstractShortfallResult, r::AbstractString, ::Colon) =
     NEUE.(x, r, x.timestamps)
 
 NEUE(x::AbstractShortfallResult, ::Colon, ::Colon) =
-    NEUE.(x, x.regions, permutedims(x.timestamps))
+    NEUE.(x, x.regions.names, permutedims(x.timestamps))
 
 include("Shortfall.jl")
 include("ShortfallSamples.jl")

--- a/PRASCore.jl/src/Results/Results.jl
+++ b/PRASCore.jl/src/Results/Results.jl
@@ -7,11 +7,12 @@ import Printf: @sprintf
 import StatsBase: mean, std, stderror
 
 import ..Systems: SystemModel, ZonedDateTime, Period,
-                  PowerUnit, EnergyUnit, conversionfactor, unitsymbol
+                  PowerUnit, EnergyUnit, conversionfactor,
+                  unitsymbol, Regions
 export
 
     # Metrics
-    ReliabilityMetric, LOLE, EUE,
+    ReliabilityMetric, LOLE, EUE, NEUE,
     val, stderror,
 
     # Result specifications
@@ -68,6 +69,12 @@ EUE(x::AbstractShortfallResult, r::AbstractString, ::Colon) =
 
 EUE(x::AbstractShortfallResult, ::Colon, ::Colon) =
     EUE.(x, x.regions, permutedims(x.timestamps))
+
+NEUE(x::AbstractShortfallResult, r::AbstractString, ::Colon) =
+    NEUE.(x, r, x.timestamps)
+
+NEUE(x::AbstractShortfallResult, ::Colon, ::Colon) =
+    NEUE.(x, x.regions, permutedims(x.timestamps))
 
 include("Shortfall.jl")
 include("ShortfallSamples.jl")

--- a/PRASCore.jl/src/Results/Shortfall.jl
+++ b/PRASCore.jl/src/Results/Shortfall.jl
@@ -23,10 +23,12 @@ sf_mean, sf_std = shortfall["Region A", period]
 # System-wide risk metrics
 eue = EUE(shortfall)
 lole = LOLE(shortfall)
+neue = NEUE(shorfall)
 
 # Regional risk metrics
 regional_eue = EUE(shortfall, "Region A")
 regional_lole = LOLE(shortfall, "Region A")
+regional_neue = NEUE(shortfall, "Region A")
 
 # Period-specific risk metrics
 period_eue = EUE(shortfall, period)

--- a/PRASCore.jl/src/Results/Shortfall.jl
+++ b/PRASCore.jl/src/Results/Shortfall.jl
@@ -120,7 +120,7 @@ accumulatortype(::Shortfall) = ShortfallAccumulator
 struct ShortfallResult{N, L, T <: Period, E <: EnergyUnit} <:
        AbstractShortfallResult{N, L, T}
     nsamples::Union{Int, Nothing}
-    regions::Vector{String}
+    regions::Regions
     timestamps::StepRange{ZonedDateTime,T}
 
     eventperiod_mean::Float64
@@ -145,7 +145,7 @@ struct ShortfallResult{N, L, T <: Period, E <: EnergyUnit} <:
 
     function ShortfallResult{N,L,T,E}(
         nsamples::Union{Int,Nothing},
-        regions::Vector{String},
+        regions::Regions,
         timestamps::StepRange{ZonedDateTime,T},
         eventperiod_mean::Float64,
         eventperiod_std::Float64,
@@ -169,7 +169,7 @@ struct ShortfallResult{N, L, T <: Period, E <: EnergyUnit} <:
         length(timestamps) == N ||
             error("The provided timestamp range does not match the simulation length")
 
-        nregions = length(regions)
+        nregions = length(regions.names)
 
         length(eventperiod_region_mean) == nregions &&
         length(eventperiod_region_std) == nregions &&
@@ -200,7 +200,7 @@ function getindex(x::ShortfallResult)
 end
 
 function getindex(x::ShortfallResult, r::AbstractString)
-    i_r = findfirstunique(x.regions, r)
+    i_r = findfirstunique(x.regions.names, r)
     return sum(view(x.shortfall_mean, i_r, :)), x.shortfall_region_std[i_r]
 end
 
@@ -210,7 +210,7 @@ function getindex(x::ShortfallResult, t::ZonedDateTime)
 end
 
 function getindex(x::ShortfallResult, r::AbstractString, t::ZonedDateTime)
-    i_r = findfirstunique(x.regions, r)
+    i_r = findfirstunique(x.regions.names, r)
     i_t = findfirstunique(x.timestamps, t)
     return x.shortfall_mean[i_r, i_t], x.shortfall_regionperiod_std[i_r, i_t]
 end
@@ -222,7 +222,7 @@ LOLE(x::ShortfallResult{N,L,T}) where {N,L,T} =
                              x.nsamples))
 
 function LOLE(x::ShortfallResult{N,L,T}, r::AbstractString) where {N,L,T}
-    i_r = findfirstunique(x.regions, r)
+    i_r = findfirstunique(x.regions.names, r)
     return LOLE{N,L,T}(MeanEstimate(x.eventperiod_region_mean[i_r],
                                     x.eventperiod_region_std[i_r],
                                     x.nsamples))
@@ -236,7 +236,7 @@ function LOLE(x::ShortfallResult{N,L,T}, t::ZonedDateTime) where {N,L,T}
 end
 
 function LOLE(x::ShortfallResult{N,L,T}, r::AbstractString, t::ZonedDateTime) where {N,L,T}
-    i_r = findfirstunique(x.regions, r)
+    i_r = findfirstunique(x.regions.names, r)
     i_t = findfirstunique(x.timestamps, t)
     return LOLE{1,L,T}(MeanEstimate(x.eventperiod_regionperiod_mean[i_r, i_t],
                                     x.eventperiod_regionperiod_std[i_r, i_t],
@@ -255,6 +255,15 @@ EUE(x::ShortfallResult{N,L,T,E}, t::ZonedDateTime) where {N,L,T,E} =
 
 EUE(x::ShortfallResult{N,L,T,E}, r::AbstractString, t::ZonedDateTime) where {N,L,T,E} =
     EUE{1,L,T,E}(MeanEstimate(x[r, t]..., x.nsamples))
+
+function NEUE(x::ShortfallResult{N,L,T,E}) where {N,L,T,E}
+    return NEUE(div(MeanEstimate(x[]..., x.nsamples),(sum(x.regions.load)/1e6)))
+end
+
+function NEUE(x::ShortfallResult{N,L,T,E}, r::AbstractString) where {N,L,T,E}
+    i_r = findfirstunique(x.regions.names, r)
+    return NEUE(div(MeanEstimate(x[r]..., x.nsamples),(sum(x.regions.load[i_r,:])/1e6)))
+end
 
 function finalize(
     acc::ShortfallAccumulator,
@@ -283,7 +292,7 @@ function finalize(
     ue_regionperiod_std .*= p2e
 
     return ShortfallResult{N,L,T,E}(
-        nsamples, system.regions.names, system.timestamps,
+        nsamples, system.regions, system.timestamps,
         ep_total_mean, ep_total_std, ep_region_mean, ep_region_std,
         ep_period_mean, ep_period_std,
         ep_regionperiod_mean, ep_regionperiod_std,

--- a/PRASCore.jl/src/Results/ShortfallSamples.jl
+++ b/PRASCore.jl/src/Results/ShortfallSamples.jl
@@ -24,10 +24,12 @@ samples = shortfall["Region A", period]
 # System-wide risk metrics
 eue = EUE(shortfall)
 lole = LOLE(shortfall)
+neue = NEUE(shortfall)
 
 # Regional risk metrics
 regional_eue = EUE(shortfall, "Region A")
 regional_lole = LOLE(shortfall, "Region A")
+regional_neue = NEUE(shortfall, "Region A")
 
 # Period-specific risk metrics
 period_eue = EUE(shortfall, period)

--- a/PRASCore.jl/src/Results/ShortfallSamples.jl
+++ b/PRASCore.jl/src/Results/ShortfallSamples.jl
@@ -73,7 +73,7 @@ accumulatortype(::ShortfallSamples) = ShortfallSamplesAccumulator
 
 struct ShortfallSamplesResult{N,L,T<:Period,P<:PowerUnit,E<:EnergyUnit} <: AbstractShortfallResult{N,L,T}
 
-    regions::Vector{String}
+    regions::Regions{N,P}
     timestamps::StepRange{ZonedDateTime,T}
 
     shortfall::Array{Int,3} # r x t x s
@@ -90,7 +90,7 @@ end
 function getindex(
     x::ShortfallSamplesResult{N,L,T,P,E}, r::AbstractString
 ) where {N,L,T,P,E}
-    i_r = findfirstunique(x.regions, r)
+    i_r = findfirstunique(x.regions.names, r)
     p2e = conversionfactor(L, T, P, E)
     return vec(p2e * sum(view(x.shortfall, i_r, :, :), dims=1))
 end
@@ -106,7 +106,7 @@ end
 function getindex(
     x::ShortfallSamplesResult{N,L,T,P,E}, r::AbstractString, t::ZonedDateTime
 ) where {N,L,T,P,E}
-    i_r = findfirstunique(x.regions, r)
+    i_r = findfirstunique(x.regions.names, r)
     i_t = findfirstunique(x.timestamps, t)
     p2e = conversionfactor(L, T, P, E)
     return vec(p2e * x.shortfall[i_r, i_t, :])
@@ -119,7 +119,7 @@ function LOLE(x::ShortfallSamplesResult{N,L,T}) where {N,L,T}
 end
 
 function LOLE(x::ShortfallSamplesResult{N,L,T}, r::AbstractString) where {N,L,T}
-    i_r = findfirstunique(x.regions, r)
+    i_r = findfirstunique(x.regions.names, r)
     eventperiods = sum(view(x.shortfall, i_r, :, :) .> 0, dims=1)
     return LOLE{N,L,T}(MeanEstimate(eventperiods))
 end
@@ -131,7 +131,7 @@ function LOLE(x::ShortfallSamplesResult{N,L,T}, t::ZonedDateTime) where {N,L,T}
 end
 
 function LOLE(x::ShortfallSamplesResult{N,L,T}, r::AbstractString, t::ZonedDateTime) where {N,L,T}
-    i_r = findfirstunique(x.regions, r)
+    i_r = findfirstunique(x.regions.names, r)
     i_t = findfirstunique(x.timestamps, t)
     eventperiods = view(x.shortfall, i_r, i_t, :) .> 0
     return LOLE{1,L,T}(MeanEstimate(eventperiods))
@@ -150,12 +150,21 @@ EUE(x::ShortfallSamplesResult{N,L,T,P,E}, t::ZonedDateTime) where {N,L,T,P,E} =
 EUE(x::ShortfallSamplesResult{N,L,T,P,E}, r::AbstractString, t::ZonedDateTime) where {N,L,T,P,E} =
     EUE{1,L,T,E}(MeanEstimate(x[r, t]))
 
+function NEUE(x::ShortfallSamplesResult{N,L,T,P,E}) where {N,L,T,P,E}
+    return NEUE(div(MeanEstimate(x[]),(sum(x.regions.load)/1e6)))
+end
+
+function NEUE(x::ShortfallSamplesResult{N,L,T,P,E}, r::AbstractString) where {N,L,T,P,E}
+    i_r = findfirstunique(x.regions.names, r)
+    return NEUE(div(MeanEstimate(x[r]),(sum(x.regions.load[i_r,:])/1e6)))
+end
+
 function finalize(
     acc::ShortfallSamplesAccumulator,
     system::SystemModel{N,L,T,P,E},
 ) where {N,L,T,P,E}
 
     return ShortfallSamplesResult{N,L,T,P,E}(
-        system.regions.names, system.timestamps, acc.shortfall)
+        system.regions, system.timestamps, acc.shortfall)
 
 end

--- a/PRASCore.jl/src/Results/metrics.jl
+++ b/PRASCore.jl/src/Results/metrics.jl
@@ -32,6 +32,9 @@ Base.isapprox(x::MeanEstimate, y::MeanEstimate) =
         isapprox(x.estimate, y.estimate) &&
         isapprox(x.standarderror, y.standarderror)
 
+Base.div(x::MeanEstimate, y::Float64) = 
+    MeanEstimate(x.estimate/y, x.standarderror/y)
+
 function Base.show(io::IO, x::MeanEstimate)
     v, s = stringprecision(x)
     print(io, v, x.standarderror > 0 ? "±"*s : "")
@@ -129,5 +132,35 @@ function Base.show(io::IO, x::EUE{N,L,T,E}) where {N,L,T,E}
 
     print(io, "EUE = ", x.eue, " ",
           unitsymbol(E), "/", N*L == 1 ? "" : N*L, unitsymbol(T))
+
+end
+
+"""
+    NEUE
+
+`NEUE` reports normalized expected unserved energy over a regional extent.
+
+Contains both the estimated value itself as well as the standard error
+of that estimate, which can be extracted with `val` and `stderror`,
+respectively.
+"""
+struct NEUE <: ReliabilityMetric
+
+    neue::MeanEstimate
+
+    function NEUE(neue::MeanEstimate)
+        val(neue) >= 0 || throw(DomainError(
+            "$val is not a valid unserved energy expectation"))
+        new(neue)
+    end
+
+end
+
+val(x::NEUE) = val(x.neue)
+stderror(x::NEUE) = stderror(x.neue)
+
+function Base.show(io::IO, x::NEUE)
+
+    print(io, "NEUE = ", x.neue, " ppm")
 
 end

--- a/PRASCore.jl/test/Results/metrics.jl
+++ b/PRASCore.jl/test/Results/metrics.jl
@@ -60,4 +60,13 @@
 
     end
 
+    @testset "NEUE" begin
+
+        neue = NEUE(MeanEstimate(1.2))
+        @test string(neue) == "NEUE = 1.20000 ppm"
+
+        @test_throws DomainError NEUE(MeanEstimate(-1.2))
+
+    end
+
 end

--- a/PRASCore.jl/test/Results/metrics.jl
+++ b/PRASCore.jl/test/Results/metrics.jl
@@ -65,6 +65,9 @@
         neue = NEUE(MeanEstimate(1.2))
         @test string(neue) == "NEUE = 1.20000 ppm"
 
+        neue2 = NEUE(MeanEstimate(17.2, 1.3))
+        @test string(neue2) == "NEUE = 17±1 ppm"
+
         @test_throws DomainError NEUE(MeanEstimate(-1.2))
 
     end

--- a/PRASCore.jl/test/Results/shortfall.jl
+++ b/PRASCore.jl/test/Results/shortfall.jl
@@ -25,8 +25,9 @@
     @test stderror(eue) ≈ last(result[]) / sqrt(DD.nsamples)
 
     neue = NEUE(result)
-    @test val(neue) ≈ (first(result[])/sum(DD.resource_vals))*1e6
-    @test stderror(neue) ≈ ((last(result[]) / sqrt(DD.nsamples))/sum(DD.resource_vals))*1e6
+    load = sum(DD.resource_vals)
+    @test val(neue) ≈ first(result[]) / load*1e6
+    @test stderror(neue) ≈ last(result[]) / sqrt(DD.nsamples) / load*1e6
     # Region-specific
 
     @test result[r] ≈ (sum(DD.d3_resourceperiod[r_idx,:]), DD.d4_resource[r_idx])
@@ -40,8 +41,9 @@
     @test stderror(region_eue) ≈ last(result[r]) / sqrt(DD.nsamples)
 
     region_neue = NEUE(result, r)
-    @test val(region_neue) ≈ (first(result[r])/sum(DD.resource_vals[DD.testresource_idx,:]))*1e6
-    @test stderror(region_neue) ≈ ((last(result[r]) / sqrt(DD.nsamples))/sum(DD.resource_vals[DD.testresource_idx,:]))*1e6
+    load = sum(DD.resource_vals[r_idx,:])
+    @test val(region_neue) ≈ first(result[r]) / load*1e6
+    @test stderror(region_neue) ≈ last(result[r]) / sqrt(DD.nsamples) / load*1e6
 
     @test_throws BoundsError result[r_bad]
     @test_throws BoundsError LOLE(result, r_bad)
@@ -117,8 +119,9 @@ end
     @test stderror(eue) ≈ std(result[]) / sqrt(DD.nsamples)
 
     neue = NEUE(result)
-    @test val(neue) ≈ (mean(result[])/sum(DD.resource_vals))*1e6
-    @test stderror(neue) ≈ ((std(result[]) / sqrt(DD.nsamples))/sum(DD.resource_vals))*1e6
+    load = sum(DD.resource_vals)
+    @test val(neue) ≈ mean(result[]) / load*1e6
+    @test stderror(neue) ≈ std(result[]) / sqrt(DD.nsamples) / load*1e6
 
     # Region-specific
 
@@ -135,8 +138,9 @@ end
     @test stderror(region_eue) ≈ std(result[r]) / sqrt(DD.nsamples)
 
     region_neue = NEUE(result, r)
-    @test val(region_neue) ≈ (mean(result[r])/sum(DD.resource_vals[DD.testresource_idx,:]))*1e6
-    @test stderror(region_neue) ≈ ((std(result[r]) / sqrt(DD.nsamples))/sum(DD.resource_vals[DD.testresource_idx,:]))*1e6
+    load = sum(DD.resource_vals[r_idx,:])
+    @test val(region_neue) ≈ mean(result[r]) / load*1e6
+    @test stderror(region_neue) ≈ std(result[r]) / sqrt(DD.nsamples) / load*1e6
 
     @test_throws BoundsError result[r_bad]
     @test_throws BoundsError LOLE(result, r_bad)

--- a/PRASCore.jl/test/Results/shortfall.jl
+++ b/PRASCore.jl/test/Results/shortfall.jl
@@ -6,7 +6,7 @@
     t, t_idx, t_bad = DD.testperiod, DD.testperiod_idx, DD.notaperiod
 
     result = PRASCore.Results.ShortfallResult{N,1,Hour,MWh}(
-        DD.nsamples, DD.resourcenames, DD.periods,
+        DD.nsamples, Regions{N,MW}(DD.resourcenames, DD.resource_vals), DD.periods,
         DD.d1, DD.d2, DD.d1_resource, DD.d2_resource,
         DD.d1_period, DD.d2_period, DD.d1_resourceperiod, DD.d2_resourceperiod,
         DD.d3_resourceperiod,
@@ -92,7 +92,7 @@ end
     t, t_idx, t_bad = DD.testperiod, DD.testperiod_idx, DD.notaperiod
 
     result = PRASCore.Results.ShortfallSamplesResult{N,1,Hour,MW,MWh}(
-        DD.resourcenames, DD.periods, DD.d)
+        Regions{N,MW}(DD.resourcenames, DD.resource_vals), DD.periods, DD.d)
 
     # Overall
 

--- a/PRASCore.jl/test/Results/shortfall.jl
+++ b/PRASCore.jl/test/Results/shortfall.jl
@@ -24,6 +24,9 @@
     @test val(eue) ≈ first(result[])
     @test stderror(eue) ≈ last(result[]) / sqrt(DD.nsamples)
 
+    neue = NEUE(result)
+    @test val(neue) ≈ (first(result[])/sum(DD.resource_vals))*1e6
+    @test stderror(neue) ≈ ((last(result[]) / sqrt(DD.nsamples))/sum(DD.resource_vals))*1e6
     # Region-specific
 
     @test result[r] ≈ (sum(DD.d3_resourceperiod[r_idx,:]), DD.d4_resource[r_idx])
@@ -36,9 +39,14 @@
     @test val(region_eue) ≈ first(result[r])
     @test stderror(region_eue) ≈ last(result[r]) / sqrt(DD.nsamples)
 
+    region_neue = NEUE(result, r)
+    @test val(region_neue) ≈ (first(result[r])/sum(DD.resource_vals[DD.testresource_idx,:]))*1e6
+    @test stderror(region_neue) ≈ ((last(result[r]) / sqrt(DD.nsamples))/sum(DD.resource_vals[DD.testresource_idx,:]))*1e6
+
     @test_throws BoundsError result[r_bad]
     @test_throws BoundsError LOLE(result, r_bad)
     @test_throws BoundsError EUE(result, r_bad)
+    @test_throws BoundsError NEUE(result, r_bad)
 
     # Period-specific
 
@@ -108,6 +116,10 @@ end
     @test val(eue) ≈ mean(result[])
     @test stderror(eue) ≈ std(result[]) / sqrt(DD.nsamples)
 
+    neue = NEUE(result)
+    @test val(neue) ≈ (mean(result[])/sum(DD.resource_vals))*1e6
+    @test stderror(neue) ≈ ((std(result[]) / sqrt(DD.nsamples))/sum(DD.resource_vals))*1e6
+
     # Region-specific
 
     @test length(result[r]) == DD.nsamples
@@ -122,9 +134,14 @@ end
     @test val(region_eue) ≈ mean(result[r])
     @test stderror(region_eue) ≈ std(result[r]) / sqrt(DD.nsamples)
 
+    region_neue = NEUE(result, r)
+    @test val(region_neue) ≈ (mean(result[r])/sum(DD.resource_vals[DD.testresource_idx,:]))*1e6
+    @test stderror(region_neue) ≈ ((std(result[r]) / sqrt(DD.nsamples))/sum(DD.resource_vals[DD.testresource_idx,:]))*1e6
+
     @test_throws BoundsError result[r_bad]
     @test_throws BoundsError LOLE(result, r_bad)
     @test_throws BoundsError EUE(result, r_bad)
+    @test_throws BoundsError NEUE(result, r_bad)
 
     # Period-specific
 

--- a/PRASCore.jl/test/dummydata.jl
+++ b/PRASCore.jl/test/dummydata.jl
@@ -21,6 +21,7 @@ notaninterface = "X"=>"Y"
 
 periods = ZonedDateTime(2012,4,1,0,tz):Hour(1):ZonedDateTime(2012,4,7,23,tz)
 nperiods = length(periods)
+resource_vals = rand(0:999, nresources, nperiods)
 testperiod_idx = 29
 testperiod = periods[testperiod_idx]
 notaperiod = ZonedDateTime(2010,1,1,0,tz)

--- a/PRASCore.jl/test/runtests.jl
+++ b/PRASCore.jl/test/runtests.jl
@@ -5,7 +5,7 @@ using Test
 using TimeZones
 
 import PRASCore.Results: MeanEstimate, ReliabilityMetric
-import PRASCore.Systems: TestData
+import PRASCore.Systems: TestData, Regions
 
 withinrange(x::ReliabilityMetric, y::Real, n::Real) =
     isapprox(val(x), y, atol=n*stderror(x))


### PR DESCRIPTION
This PR modifies Shortfall and ShortfallSamples results to export PRASCore.Regions instead of just Regions names to make calculation of NEUE possible just with these objects. This PR also enables NEUE calculation using Shortfall or ShortfallSamples results. I also added tests for the new capability and modify tesst that were failing. I didn't change any of the Simulations tests