### PR TITLE
Allow for additional user defined attributes in PRAS HDF5

### DIFF
--- a/PRAS.jl/src/PRAS.jl
+++ b/PRAS.jl/src/PRAS.jl
@@ -6,6 +6,6 @@ using Reexport
 @reexport using PRASFiles
 @reexport using PRASCapacityCredits
 
-import PRASFiles: toymodel, rts_gmlc
+import PRASFiles: toymodel, rts_gmlc, read_addl_attrs
 
 end

--- a/PRASFiles.jl/src/Systems/read.jl
+++ b/PRASFiles.jl/src/Systems/read.jl
@@ -294,6 +294,33 @@ function readversion(f::File)
 end
 
 """
+Reads additional user defined metadata from the file containing the PRAS system.
+"""
+function read_addl_attrs(inputfile::String)
+
+    h5open(inputfile, "r") do f::File
+
+        metadata = attributes(f)
+
+        reqd_attrs_keys = ["pras_dataversion", "start_timestamp", "timestep_count",
+                    "timestep_length", "timestep_unit", "power_unit", "energy_unit"]
+        
+        addl_attrs_keys = setdiff(keys(metadata), reqd_attrs_keys)
+        
+        if !isempty(addl_attrs_keys)            
+            println("User-defined attribute(s) found in the file:")
+            for key in addl_attrs_keys
+                println("  $key: $(read(metadata[key]))")
+            end
+
+            return Dict(key => read(metadata[key]) for key in addl_attrs_keys)
+        else
+            println("No user-defined attributes found in the file.")
+        end
+    end
+end
+
+"""
 Attempts to extract a vector of elements from an HDF5 compound datatype,
 corresponding to `field`.
 """

--- a/PRASFiles.jl/src/Systems/write.jl
+++ b/PRASFiles.jl/src/Systems/write.jl
@@ -5,7 +5,8 @@ Export a PRAS SystemModel `sys` as a .pras file, saved to `outfile`
 """
 function savemodel(
     sys::SystemModel, outfile::String;
-    string_length::Int=64, compression_level::Int=1, verbose::Bool=false)
+    string_length::Int=64, compression_level::Int=1, verbose::Bool=false,
+    user_attributes::Union{Dict{String, String},Nothing}=nothing)  
 
     verbose &&
         @info "The PRAS system being exported is of type $(typeof(sys))"
@@ -13,7 +14,8 @@ function savemodel(
     h5open(outfile, "w") do f::File
 
         verbose && @info "Processing metadata for .pras file ..."
-        process_metadata!(f, sys)
+        process_metadata!(f, sys;
+                          user_attributes=user_attributes)
 
         verbose && @info "Processing Regions for .pras file ..."
         process_regions!(f, sys, string_length, compression_level)
@@ -54,7 +56,8 @@ function savemodel(
 end
 
 function process_metadata!(
-    f::File, sys::SystemModel{N,L,T,P,E}) where {N,L,T,P,E}
+    f::File, sys::SystemModel{N,L,T,P,E};
+    user_attributes::Union{Dict{String, String},Nothing}=nothing) where {N,L,T,P,E}
 
     attrs = attributes(f)
     
@@ -66,6 +69,12 @@ function process_metadata!(
 
     attrs["start_timestamp"] = string(sys.timestamps.start);
     attrs["pras_dataversion"] = PRASFILE_VERSION
+
+    if !isnothing(user_attributes)
+        for (key, value) in user_attributes
+            attrs[key] = value
+        end
+    end
 
     return
 

--- a/PRASFiles.jl/test/runtests.jl
+++ b/PRASFiles.jl/test/runtests.jl
@@ -20,6 +20,11 @@ using JSON3
         rts2 = SystemModel(path * "/rts2.pras")
         @test rts == rts2
 
+        savemodel(rts,path * "rts_userattrs.pras",
+        user_attributes=Dict("about"=>"this is a representation of the RTS GMLC system"))
+        user_attrs = PRASFiles.read_addl_attrs(path * "rts_userattrs.pras") 
+        @test user_attrs == Dict("about"=>"this is a representation of the RTS GMLC system")
+
     end
 
     @testset "Run RTS-GMLC" begin


### PR DESCRIPTION
Added ability to record additional user defined attributes as string key, value pairs. This can be passed to `savemodel` as a Dict. Also added functionality to read these "additional" attributes from the saved file. 

This can be used to record information about the source of data that went into create the PRAS system, for example the ReEDS version if we used R2P, where weather data came from (NSRD/WTK or climate simulations etc). 