### PR TITLE
Return zero NEUE when a region's demand is zero

### DIFF
--- a/PRASCore.jl/Project.toml
+++ b/PRASCore.jl/Project.toml
@@ -6,7 +6,7 @@ authors = [
     "Srihari Sundar <Hari.Sundar@nrel.gov>",
     "Julian Florez <Julian.Florez@nrel.gov"
 ]
-version = "0.8.0"
+version = "0.8.1"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/PRASCore.jl/src/Results/Shortfall.jl
+++ b/PRASCore.jl/src/Results/Shortfall.jl
@@ -263,12 +263,33 @@ EUE(x::ShortfallResult{N,L,T,E}, r::AbstractString, t::ZonedDateTime) where {N,L
     EUE{1,L,T,E}(MeanEstimate(x[r, t]..., x.nsamples))
 
 function NEUE(x::ShortfallResult)  
-    return NEUE(div(MeanEstimate(x[]..., x.nsamples),(sum(x.regions.load)/1e6)))
+
+    demand = sum(x.regions.load)
+
+    estimate = if demand > 0
+        div(MeanEstimate(x[]..., x.nsamples), demand/1e6)
+    else
+        MeanEstimate(0.)
+    end
+
+    return NEUE(estimate)
+
 end
 
 function NEUE(x::ShortfallResult, r::AbstractString) 
+
     i_r = findfirstunique(x.regions.names, r)
-    return NEUE(div(MeanEstimate(x[r]..., x.nsamples),(sum(x.regions.load[i_r,:])/1e6)))
+
+    demand = sum(x.regions.load[i_r, :])
+
+    estimate = if demand > 0
+        div(MeanEstimate(x[r]..., x.nsamples), demand/1e6)
+    else
+        MeanEstimate(0.)
+    end
+
+    return NEUE(estimate)
+
 end
 
 function finalize(

--- a/PRASCore.jl/src/Results/ShortfallSamples.jl
+++ b/PRASCore.jl/src/Results/ShortfallSamples.jl
@@ -155,13 +155,34 @@ EUE(x::ShortfallSamplesResult{N,L,T,P,E}, t::ZonedDateTime) where {N,L,T,P,E} =
 EUE(x::ShortfallSamplesResult{N,L,T,P,E}, r::AbstractString, t::ZonedDateTime) where {N,L,T,P,E} =
     EUE{1,L,T,E}(MeanEstimate(x[r, t]))
 
-function NEUE(x::ShortfallSamplesResult{N,L,T,P,E}) where {N,L,T,P,E}
-    return NEUE(div(MeanEstimate(x[]),(sum(x.regions.load)/1e6)))
+function NEUE(x::ShortfallSamplesResult)
+
+    demand = sum(x.regions.load)
+
+    estimate = if demand > 0
+        div(MeanEstimate(x[]), demand/1e6)
+    else
+        MeanEstimate(0.)
+    end
+
+    return NEUE(estimate)
+
 end
 
-function NEUE(x::ShortfallSamplesResult{N,L,T,P,E}, r::AbstractString) where {N,L,T,P,E}
+function NEUE(x::ShortfallSamplesResult, r::AbstractString)
+
     i_r = findfirstunique(x.regions.names, r)
-    return NEUE(div(MeanEstimate(x[r]),(sum(x.regions.load[i_r,:])/1e6)))
+
+    demand = sum(x.regions.load[i_r, :])
+
+    estimate = if demand > 0
+        div(MeanEstimate(x[r]), demand/1e6)
+    else
+        MeanEstimate(0.)
+    end
+
+    return NEUE(estimate)
+
 end
 
 function finalize(


### PR DESCRIPTION
Right now, if any region has zero demand, NEUE is calculated as 0/0 which causes PRAS to throw an error and fail to report the metric. This would be more correct if EUE could be positive in that situation, but since it's impossible to have dropped load in a region without any load, reporting 0 NEUE seems like a reasonable alternative. This PR adds a check for the zero load condition and manually reports 0 NEUE in those cases.