### PR TITLE
Add Unserved energy Conditional Value at Risk (CVAR) metric

### DIFF
--- a/PRAS.jl/examples/pras_walkthrough.jl
+++ b/PRAS.jl/examples/pras_walkthrough.jl
@@ -188,20 +188,18 @@ println("Surplus in")
 # Currently, PRAS implements only unserved energy CVAR. 
 
 # Start by defining the confidence level $\alpha$, which defines the tail threshold beyond which we
-# want measure the expected shortfall. Also, we want to define the CVAR unit type.
-# Only energy units are accepted (e.g., `kWh`, `MWh`, `GWh`, or `TWh`). 
+# want measure the expected shortfall.
 
 alpha = 0.95 # nth percentile for tail events
-energyunit = MWh # energy type
 
 # We can check the overall system unserved energy CVAR
 
-ue_cvar = CVAR(energyunit, shortfall, alpha)
+ue_cvar = CVAR(:energy, shortfall, alpha)
 println("System CVAR: $(ue_cvar)")
 
 # And we can calculate the noramzlied CVAR (NCVAR)
 ue_ncvar = NCVAR(shortfall, ue_cvar)
-println("System CVAR: $(ue_cvar)")
+println("System NCVAR: $(ue_ncvar)")
 
 # We can also find the unserved energy CVAR by region
-regional_ue_cvar = CVAR.(energyunit, shortfall, alpha, sys.regions.names)
+regional_ue_cvar = CVAR.(:energy, shortfall, alpha, sys.regions.names)

--- a/PRAS.jl/examples/pras_walkthrough.jl
+++ b/PRAS.jl/examples/pras_walkthrough.jl
@@ -176,3 +176,32 @@ println("Surplus in")
 # performed on the subset of samples in which the event was observed, using the
 # `ShortfallSamples`, `UtilizationSamples`, and
 # `StorageEnergySamples` result specifications instead.
+
+## [Assess tail-risk metrics](@id assess_tail_risks)
+
+# PRAS can calculate the risk-tail adequacy metrics, which are useful when analyzing extreme
+# occurences of shortfall events. The Conditional Value at Risk (CVAR) measures the weighted 
+# average outcomes beyond a pre-defined percentile $\alpha$. Therefore, the CVAR calculates
+# the expected shortfalls in the worst $(1-\alpha)$ outcomes. 
+# In general, CVAR can be used for calculating tail-risk outcomes across any of the resource
+# adequacy planning dimensions (energy shortfall, duration, and magnitude).
+# Currently, PRAS implements only unserved energy CVAR. 
+
+# Start by defining the confidence level $\alpha$, which defines the tail threshold beyond which we
+# want measure the expected shortfall. Also, we want to define the CVAR unit type.
+# Only energy units are accepted (e.g., `kWh`, `MWh`, `GWh`, or `TWh`). 
+
+alpha = 0.95 # nth percentile for tail events
+energyunit = MWh # energy type
+
+# We can check the overall system unserved energy CVAR
+
+ue_cvar = CVAR(energyunit, shortfall, alpha)
+println("System CVAR: $(ue_cvar)")
+
+# And we can calculate the noramzlied CVAR (NCVAR)
+ue_ncvar = NCVAR(shortfall, ue_cvar)
+println("System CVAR: $(ue_cvar)")
+
+# We can also find the unserved energy CVAR by region
+regional_ue_cvar = CVAR.(energyunit, shortfall, alpha, sys.regions.names)

--- a/PRAS.jl/test/runtests.jl
+++ b/PRAS.jl/test/runtests.jl
@@ -1,15 +1,40 @@
 using PRAS
 using Test
 
-sys = PRAS.rts_gmlc()
+@testset "ShortfallResult" begin
+    sys = PRAS.rts_gmlc()
 
-sf, = assess(sys, SequentialMonteCarlo(samples=100), Shortfall())
+    sf, = assess(sys, SequentialMonteCarlo(samples=100), Shortfall())
 
-eue = EUE(sf)
-lole = LOLE(sf)
-neue = NEUE(sf)
+    eue = EUE(sf)
+    lole = LOLE(sf)
+    neue = NEUE(sf)
 
-@test val(eue) isa Float64
-@test stderror(eue) isa Float64
-@test val(neue) isa Float64
-@test stderror(neue) isa Float64
+    @test val(eue) isa Float64
+    @test stderror(eue) isa Float64
+    @test val(neue) isa Float64
+    @test stderror(neue) isa Float64
+end
+
+@testset "ShortfallSamplesResult" begin
+    sys = PRAS.rts_gmlc()
+
+    sf, = assess(sys, SequentialMonteCarlo(samples=100), ShortfallSamples())
+
+    eue = EUE(sf)
+    lole = LOLE(sf)
+    neue = NEUE(sf)
+
+    alpha = 0.95
+    cvar = CVAR(sf, alpha)
+    ncvar = NCVAR(sf, cvar)
+
+    @test val(eue) isa Float64
+    @test stderror(eue) isa Float64
+    @test val(neue) isa Float64
+    @test stderror(neue) isa Float64
+    @test val(cvar) isa Float64
+    @test stderror(cvar) isa Float64
+    @test val(ncvar) isa Float64
+    @test stderror(ncvar) isa Float64
+end

--- a/PRAS.jl/test/runtests.jl
+++ b/PRAS.jl/test/runtests.jl
@@ -11,8 +11,7 @@ using Test
     neue = NEUE(sf)
 
     alpha = 0.95
-    (timesteps,periodunit,periodunit,powerunit,energyunit) = get_params(rts_gmlc())
-    cvar = CVAR(energyunit, sf, alpha)
+    cvar = CVAR(:energy, sf, alpha)
     ncvar = NCVAR(sf, cvar)
 
     @test val(eue) isa Float64
@@ -36,8 +35,7 @@ end
     neue = NEUE(sf)
 
     alpha = 0.95
-    (timesteps,periodunit,periodunit,powerunit,energyunit) = get_params(rts_gmlc())
-    cvar = CVAR(energyunit, sf, alpha)
+    cvar = CVAR(:energy, sf, alpha)
     ncvar = NCVAR(sf, cvar)
 
     @test val(eue) isa Float64

--- a/PRAS.jl/test/runtests.jl
+++ b/PRAS.jl/test/runtests.jl
@@ -10,10 +10,19 @@ using Test
     lole = LOLE(sf)
     neue = NEUE(sf)
 
+    alpha = 0.95
+    cvar = CVAR(sf, alpha)
+    ncvar = NCVAR(sf, cvar)
+
     @test val(eue) isa Float64
     @test stderror(eue) isa Float64
     @test val(neue) isa Float64
     @test stderror(neue) isa Float64
+    @test val(cvar) isa Float64
+    @test stderror(cvar) isa Float64
+    @test val(ncvar) isa Float64
+    @test stderror(ncvar) isa Float64
+
 end
 
 @testset "ShortfallSamplesResult" begin

--- a/PRAS.jl/test/runtests.jl
+++ b/PRAS.jl/test/runtests.jl
@@ -11,6 +11,7 @@ using Test
     neue = NEUE(sf)
 
     alpha = 0.95
+    (timesteps,periodunit,periodunit,powerunit,energyunit) = get_params(rts_gmlc())
     cvar = CVAR(energyunit, sf, alpha)
     ncvar = NCVAR(sf, cvar)
 
@@ -35,6 +36,7 @@ end
     neue = NEUE(sf)
 
     alpha = 0.95
+    (timesteps,periodunit,periodunit,powerunit,energyunit) = get_params(rts_gmlc())
     cvar = CVAR(energyunit, sf, alpha)
     ncvar = NCVAR(sf, cvar)
 

--- a/PRAS.jl/test/runtests.jl
+++ b/PRAS.jl/test/runtests.jl
@@ -11,7 +11,7 @@ using Test
     neue = NEUE(sf)
 
     alpha = 0.95
-    cvar = CVAR(sf, alpha)
+    cvar = CVAR(energyunit, sf, alpha)
     ncvar = NCVAR(sf, cvar)
 
     @test val(eue) isa Float64
@@ -35,7 +35,7 @@ end
     neue = NEUE(sf)
 
     alpha = 0.95
-    cvar = CVAR(sf, alpha)
+    cvar = CVAR(energyunit, sf, alpha)
     ncvar = NCVAR(sf, cvar)
 
     @test val(eue) isa Float64

--- a/PRASCore.jl/src/Results/Results.jl
+++ b/PRASCore.jl/src/Results/Results.jl
@@ -27,27 +27,8 @@ export
     GeneratorStorageAvailability,DemandResponseAvailability,
     LineAvailability
 
-include("utils.jl")
 include("metrics.jl")
-
-function _cvar(estimate::AbstractVector{<:Real}, alpha::Float64)
-    var = quantile(estimate, alpha)
-    tail = estimate[estimate .> var]   
-    cvar = isempty(tail) ? MeanEstimate(0.) : MeanEstimate(tail)
-    return cvar, var
-end
-
-function _ncvar(cvar::CVAR, demand::Real)
-    if demand > 0
-        scale = demand / 1e6
-        ncvar = div(cvar.cvar, scale)
-        var = cvar.var / scale
-    else
-        ncvar = MeanEstimate(0.)
-        var = 0.0
-    end
-    return ncvar, var
-end
+include("utils.jl")
 
 abstract type ResultSpec end
 
@@ -101,7 +82,6 @@ NEUE(x::AbstractShortfallResult, ::Colon, ::Colon) =
 
 CVAR(dim::Symbol, x::AbstractShortfallResult, alpha::Float64, args...) =
     CVAR(Val(dim), x, alpha, args...)
-
 
 function CVAR(::Val, ::AbstractShortfallResult, ::Float64, args...)
     throw(ArgumentError("Invalid dim, use one of $CVAR_METRICS"))

--- a/PRASCore.jl/src/Results/Results.jl
+++ b/PRASCore.jl/src/Results/Results.jl
@@ -80,22 +80,20 @@ NEUE(x::AbstractShortfallResult, r::AbstractString, ::Colon) =
 NEUE(x::AbstractShortfallResult, ::Colon, ::Colon) =
     NEUE.(x, x.regions.names, permutedims(x.timestamps))
 
-##TODO: Need to check these CVAR and NCVAR implementations
-CVAR(x::AbstractShortfallResult, ::Colon, t::ZonedDateTime) =
-    CVAR.(x, x.regions.names, t)
+CVAR(x::AbstractShortfallResult, alpha::Float64, ::Colon, t::ZonedDateTime) =
+    CVAR.(x, alpha, x.regions.names, t)
 
-CVAR(x::AbstractShortfallResult, r::AbstractString, ::Colon) =
-    CVAR.(x, r, x.timestamps)
+CVAR(x::AbstractShortfallResult, alpha::Float64, r::AbstractString, ::Colon) =
+    CVAR.(x, alpha, r, x.timestamps)
 
-CVAR(x::AbstractShortfallResult, ::Colon, ::Colon) =
-    CVAR.(x, x.regions.names, permutedims(x.timestamps))    
+CVAR(x::AbstractShortfallResult, alpha::Float64, ::Colon, ::Colon) =
+    CVAR.(x, alpha, x.regions.names, permutedims(x.timestamps))    
 
-NCVAR(x::AbstractShortfallResult, r::AbstractString, ::Colon) =
-    NCVAR.(x, r, x.timestamps)
+NCVAR(x::AbstractShortfallResult, alpha::Float64, r::AbstractString, ::Colon) =
+    NCVAR.(x, alpha, r, x.timestamps)
 
-NCVAR(x::AbstractShortfallResult, ::Colon, ::Colon) =
-    NCVAR.(x, x.regions.names, permutedims(x.timestamps))
-
+NCVAR(x::AbstractShortfallResult, alpha::Float64, ::Colon, ::Colon) =
+    NCVAR.(x, alpha, x.regions.names, permutedims(x.timestamps))
 include("Shortfall.jl")
 include("ShortfallSamples.jl")
 

--- a/PRASCore.jl/src/Results/Results.jl
+++ b/PRASCore.jl/src/Results/Results.jl
@@ -13,7 +13,7 @@ export
 
     # Metrics
     ReliabilityMetric, LOLE, EUE, NEUE,
-    val, stderror, CVAR, NCVAR, 
+    val, stderror, CVAR, NCVAR,
 
     # Result specifications
     Shortfall, ShortfallSamples,

--- a/PRASCore.jl/src/Results/Results.jl
+++ b/PRASCore.jl/src/Results/Results.jl
@@ -30,6 +30,25 @@ export
 include("utils.jl")
 include("metrics.jl")
 
+function _cvar(estimate::AbstractVector{<:Real}, alpha::Float64)
+    var = quantile(estimate, alpha)
+    tail = estimate[estimate .> var]   
+    cvar = isempty(tail) ? MeanEstimate(0.) : MeanEstimate(tail)
+    return cvar, var
+end
+
+function _ncvar(cvar::CVAR, demand::Real)
+    if demand > 0
+        scale = demand / 1e6
+        ncvar = div(cvar.cvar, scale)
+        var = cvar.var / scale
+    else
+        ncvar = MeanEstimate(0.)
+        var = 0.0
+    end
+    return ncvar, var
+end
+
 abstract type ResultSpec end
 
 abstract type ResultAccumulator{R<:ResultSpec} end
@@ -80,14 +99,21 @@ NEUE(x::AbstractShortfallResult, r::AbstractString, ::Colon) =
 NEUE(x::AbstractShortfallResult, ::Colon, ::Colon) =
     NEUE.(x, x.regions.names, permutedims(x.timestamps))
 
-CVAR(unit::Type{U}, x::AbstractShortfallResult, alpha::Float64, ::Colon, t::ZonedDateTime) where {U<:EnergyUnit} =
-    CVAR.(unit, x, alpha, x.regions.names, t)
+CVAR(dim::Symbol, x::AbstractShortfallResult, alpha::Float64, args...) =
+    CVAR(Val(dim), x, alpha, args...)
 
-CVAR(unit::Type{U}, x::AbstractShortfallResult, alpha::Float64, r::AbstractString, ::Colon) where {U<:EnergyUnit} =
-    CVAR.(unit, x, alpha, r, x.timestamps)
+CVAR(dim::Symbol, x::AbstractShortfallResult, alpha::Float64, ::Colon, t::ZonedDateTime) =
+    CVAR.(dim, x, alpha, x.regions.names, t)
 
-CVAR(unit::Type{U}, x::AbstractShortfallResult, alpha::Float64, ::Colon, ::Colon) where {U<:EnergyUnit} =
-    CVAR.(unit, x, alpha, x.regions.names, permutedims(x.timestamps))
+CVAR(dim::Symbol, x::AbstractShortfallResult, alpha::Float64, r::AbstractString, ::Colon) =
+    CVAR.(dim, x, alpha, r, x.timestamps)
+
+CVAR(dim::Symbol, x::AbstractShortfallResult, alpha::Float64, ::Colon, ::Colon) =
+    CVAR.(dim, x, alpha, x.regions.names, permutedims(x.timestamps))
+
+function CVAR(::Val, ::AbstractShortfallResult, ::Float64, args...)
+    throw(ArgumentError("Invalid dim, use one of $CVAR_METRICS"))
+end
 
 NCVAR(x::AbstractShortfallResult, cvar::CVAR, ::Colon) =
     NCVAR.(x, cvar, x.regions.names)

--- a/PRASCore.jl/src/Results/Results.jl
+++ b/PRASCore.jl/src/Results/Results.jl
@@ -13,7 +13,7 @@ export
 
     # Metrics
     ReliabilityMetric, LOLE, EUE, NEUE,
-    val, stderror, CVAR, NCVAR,
+    val, stderror, CVAR, NCVAR, 
 
     # Result specifications
     Shortfall, ShortfallSamples,
@@ -79,6 +79,22 @@ NEUE(x::AbstractShortfallResult, r::AbstractString, ::Colon) =
 
 NEUE(x::AbstractShortfallResult, ::Colon, ::Colon) =
     NEUE.(x, x.regions.names, permutedims(x.timestamps))
+
+##TODO: Need to check these CVAR and NCVAR implementations
+CVAR(x::AbstractShortfallResult, ::Colon, t::ZonedDateTime) =
+    CVAR.(x, x.regions.names, t)
+
+CVAR(x::AbstractShortfallResult, r::AbstractString, ::Colon) =
+    CVAR.(x, r, x.timestamps)
+
+CVAR(x::AbstractShortfallResult, ::Colon, ::Colon) =
+    CVAR.(x, x.regions.names, permutedims(x.timestamps))    
+
+NCVAR(x::AbstractShortfallResult, r::AbstractString, ::Colon) =
+    NCVAR.(x, r, x.timestamps)
+
+NCVAR(x::AbstractShortfallResult, ::Colon, ::Colon) =
+    NCVAR.(x, x.regions.names, permutedims(x.timestamps))
 
 include("Shortfall.jl")
 include("ShortfallSamples.jl")

--- a/PRASCore.jl/src/Results/Results.jl
+++ b/PRASCore.jl/src/Results/Results.jl
@@ -89,11 +89,8 @@ CVAR(unit::Type{U}, x::AbstractShortfallResult, alpha::Float64, r::AbstractStrin
 CVAR(unit::Type{U}, x::AbstractShortfallResult, alpha::Float64, ::Colon, ::Colon) where {U<:EnergyUnit} =
     CVAR.(unit, x, alpha, x.regions.names, permutedims(x.timestamps))
 
-NCVAR(x::AbstractShortfallResult, cvar::CVAR, r::AbstractString, ::Colon) =
-    NCVAR.(x, cvar, r, x.timestamps)
-
-NCVAR(x::AbstractShortfallResult, cvar::CVAR, ::Colon, ::Colon) =
-    NCVAR.(x, cvar, x.regions.names, permutedims(x.timestamps))
+NCVAR(x::AbstractShortfallResult, cvar::CVAR, ::Colon) =
+    NCVAR.(x, cvar, x.regions.names)
 include("Shortfall.jl")
 include("ShortfallSamples.jl")
 

--- a/PRASCore.jl/src/Results/Results.jl
+++ b/PRASCore.jl/src/Results/Results.jl
@@ -13,7 +13,7 @@ export
 
     # Metrics
     ReliabilityMetric, LOLE, EUE, NEUE,
-    val, stderror, CVAR,
+    val, stderror, CVAR, NCVAR,
 
     # Result specifications
     Shortfall, ShortfallSamples,

--- a/PRASCore.jl/src/Results/Results.jl
+++ b/PRASCore.jl/src/Results/Results.jl
@@ -102,14 +102,6 @@ NEUE(x::AbstractShortfallResult, ::Colon, ::Colon) =
 CVAR(dim::Symbol, x::AbstractShortfallResult, alpha::Float64, args...) =
     CVAR(Val(dim), x, alpha, args...)
 
-CVAR(dim::Symbol, x::AbstractShortfallResult, alpha::Float64, ::Colon, t::ZonedDateTime) =
-    CVAR.(dim, x, alpha, x.regions.names, t)
-
-CVAR(dim::Symbol, x::AbstractShortfallResult, alpha::Float64, r::AbstractString, ::Colon) =
-    CVAR.(dim, x, alpha, r, x.timestamps)
-
-CVAR(dim::Symbol, x::AbstractShortfallResult, alpha::Float64, ::Colon, ::Colon) =
-    CVAR.(dim, x, alpha, x.regions.names, permutedims(x.timestamps))
 
 function CVAR(::Val, ::AbstractShortfallResult, ::Float64, args...)
     throw(ArgumentError("Invalid dim, use one of $CVAR_METRICS"))

--- a/PRASCore.jl/src/Results/Results.jl
+++ b/PRASCore.jl/src/Results/Results.jl
@@ -84,7 +84,7 @@ CVAR(dim::Symbol, x::AbstractShortfallResult, alpha::Float64, args...) =
     CVAR(Val(dim), x, alpha, args...)
 
 function CVAR(::Val, ::AbstractShortfallResult, ::Float64, args...)
-    throw(ArgumentError("Invalid dim, use one of $CVAR_METRICS"))
+    throw(ArgumentError("Invalid quantity, use one of $CVAR_QUANTITIES"))
 end
 
 NCVAR(x::AbstractShortfallResult, cvar::CVAR, ::Colon) =

--- a/PRASCore.jl/src/Results/Results.jl
+++ b/PRASCore.jl/src/Results/Results.jl
@@ -4,7 +4,7 @@ import Base: broadcastable, getindex, merge!
 import OnlineStats: Series
 import OnlineStatsBase: EqualWeight, Mean, Variance, value
 import Printf: @sprintf
-import StatsBase: mean, std, stderror
+import StatsBase: mean, std, stderror, quantile
 
 import ..Systems: SystemModel, ZonedDateTime, Period,
                   PowerUnit, EnergyUnit, conversionfactor,
@@ -13,7 +13,7 @@ export
 
     # Metrics
     ReliabilityMetric, LOLE, EUE, NEUE,
-    val, stderror,
+    val, stderror, CVAR,
 
     # Result specifications
     Shortfall, ShortfallSamples,

--- a/PRASCore.jl/src/Results/Results.jl
+++ b/PRASCore.jl/src/Results/Results.jl
@@ -80,14 +80,14 @@ NEUE(x::AbstractShortfallResult, r::AbstractString, ::Colon) =
 NEUE(x::AbstractShortfallResult, ::Colon, ::Colon) =
     NEUE.(x, x.regions.names, permutedims(x.timestamps))
 
-CVAR(x::AbstractShortfallResult, alpha::Float64, ::Colon, t::ZonedDateTime) =
-    CVAR.(x, alpha, x.regions.names, t)
+CVAR(unit::Type{U}, x::AbstractShortfallResult, alpha::Float64, ::Colon, t::ZonedDateTime) where {U<:EnergyUnit} =
+    CVAR.(unit, x, alpha, x.regions.names, t)
 
-CVAR(x::AbstractShortfallResult, alpha::Float64, r::AbstractString, ::Colon) =
-    CVAR.(x, alpha, r, x.timestamps)
+CVAR(unit::Type{U}, x::AbstractShortfallResult, alpha::Float64, r::AbstractString, ::Colon) where {U<:EnergyUnit} =
+    CVAR.(unit, x, alpha, r, x.timestamps)
 
-CVAR(x::AbstractShortfallResult, alpha::Float64, ::Colon, ::Colon) =
-    CVAR.(x, alpha, x.regions.names, permutedims(x.timestamps))    
+CVAR(unit::Type{U}, x::AbstractShortfallResult, alpha::Float64, ::Colon, ::Colon) where {U<:EnergyUnit} =
+    CVAR.(unit, x, alpha, x.regions.names, permutedims(x.timestamps))
 
 NCVAR(x::AbstractShortfallResult, cvar::CVAR, r::AbstractString, ::Colon) =
     NCVAR.(x, cvar, r, x.timestamps)

--- a/PRASCore.jl/src/Results/Results.jl
+++ b/PRASCore.jl/src/Results/Results.jl
@@ -89,11 +89,11 @@ CVAR(x::AbstractShortfallResult, alpha::Float64, r::AbstractString, ::Colon) =
 CVAR(x::AbstractShortfallResult, alpha::Float64, ::Colon, ::Colon) =
     CVAR.(x, alpha, x.regions.names, permutedims(x.timestamps))    
 
-NCVAR(x::AbstractShortfallResult, alpha::Float64, r::AbstractString, ::Colon) =
-    NCVAR.(x, alpha, r, x.timestamps)
+NCVAR(x::AbstractShortfallResult, cvar::CVAR, r::AbstractString, ::Colon) =
+    NCVAR.(x, cvar, r, x.timestamps)
 
-NCVAR(x::AbstractShortfallResult, alpha::Float64, ::Colon, ::Colon) =
-    NCVAR.(x, alpha, x.regions.names, permutedims(x.timestamps))
+NCVAR(x::AbstractShortfallResult, cvar::CVAR, ::Colon, ::Colon) =
+    NCVAR.(x, cvar, x.regions.names, permutedims(x.timestamps))
 include("Shortfall.jl")
 include("ShortfallSamples.jl")
 

--- a/PRASCore.jl/src/Results/Shortfall.jl
+++ b/PRASCore.jl/src/Results/Shortfall.jl
@@ -341,7 +341,7 @@ function NCVAR(x::ShortfallResult, cvar::CVAR)
 
     ncvar, var = _ncvar(cvar, demand)
 
-    return NCVAR(cvar.dim, ncvar, cvar.alpha, var)
+    return NCVAR(cvar.quantity, ncvar, cvar.alpha, var)
 end
 
 function NCVAR(x::ShortfallResult, cvar::CVAR, r::AbstractString)
@@ -350,7 +350,7 @@ function NCVAR(x::ShortfallResult, cvar::CVAR, r::AbstractString)
 
     ncvar, var = _ncvar(cvar, demand)
 
-    return NCVAR(cvar.dim, ncvar, cvar.alpha, var)
+    return NCVAR(cvar.quantity, ncvar, cvar.alpha, var)
   
 end
 

--- a/PRASCore.jl/src/Results/Shortfall.jl
+++ b/PRASCore.jl/src/Results/Shortfall.jl
@@ -270,13 +270,13 @@ end
 EUE(x::ShortfallResult{N,L,T,E}) where {N,L,T,E} =
     EUE{N,L,T,E}(MeanEstimate(x[]..., x.nsamples))
 
-EUE(x::ShortfallResult{N,L,T,E},r::AbstractString) where {N,L,T,E} =
+EUE(x::ShortfallResult{N,L,T,E}, r::AbstractString) where {N,L,T,E} =
     EUE{N,L,T,E}(MeanEstimate(x[r]..., x.nsamples))
 
-EUE(x::ShortfallResult{N,L,T,E},t::ZonedDateTime) where {N,L,T,E} =
+EUE(x::ShortfallResult{N,L,T,E}, t::ZonedDateTime) where {N,L,T,E} =
     EUE{1,L,T,E}(MeanEstimate(x[t]..., x.nsamples))
 
-EUE(x::ShortfallResult{N,L,T,E},r::AbstractString, t::ZonedDateTime) where {N,L,T,E} =
+EUE(x::ShortfallResult{N,L,T,E}, r::AbstractString, t::ZonedDateTime) where {N,L,T,E} =
     EUE{1,L,T,E}(MeanEstimate(x[r, t]..., x.nsamples))
 
 function NEUE(x::ShortfallResult)  

--- a/PRASCore.jl/src/Results/Shortfall.jl
+++ b/PRASCore.jl/src/Results/Shortfall.jl
@@ -415,7 +415,7 @@ function finalize(
     nsamples = first(acc.unservedload_total.stats).n
 
     p2e = conversionfactor(L,T,P,E)
-    capacity_shortfall_mean = ue_regionperiod_mean
+    capacity_shortfall_mean = copy(ue_regionperiod_mean)
     ue_regionperiod_mean .*= p2e
     ue_total_std *= p2e
     ue_region_std .*= p2e

--- a/PRASCore.jl/src/Results/Shortfall.jl
+++ b/PRASCore.jl/src/Results/Shortfall.jl
@@ -415,7 +415,7 @@ function finalize(
     nsamples = first(acc.unservedload_total.stats).n
 
     p2e = conversionfactor(L,T,P,E)
-    capacity_shortfall_mean = copy(ue_regionperiod_mean)
+    capacity_shortfall_mean = ue_regionperiod_mean
     ue_regionperiod_mean .*= p2e
     ue_total_std *= p2e
     ue_region_std .*= p2e

--- a/PRASCore.jl/src/Results/Shortfall.jl
+++ b/PRASCore.jl/src/Results/Shortfall.jl
@@ -311,7 +311,7 @@ function NEUE(x::ShortfallResult, r::AbstractString)
 
 end
 
-function CVAR(x::ShortfallResult{N,L,T,E}, alpha::Float64) where {N,L,T,E}
+function CVAR(unit::Type{U}, x::ShortfallResult{N,L,T,E}, alpha::Float64) where {N,L,T,E,U<:EnergyUnit}
 
     estimate = x.shortfall_samples
     var = quantile(estimate, alpha)
@@ -323,21 +323,27 @@ function CVAR(x::ShortfallResult{N,L,T,E}, alpha::Float64) where {N,L,T,E}
         MeanEstimate(0.)
     end                                                           
 
-    capacity_estimate = x.capacity_shortfall_mean[:]
-    capacity_var = quantile(capacity_estimate, alpha)
-    capacity_tail_losses = capacity_estimate[capacity_estimate .>= capacity_var]
+    return CVAR{N,L,T,E}(unit, cvar, alpha, var)
+  
+end
 
-    capacity_cvar = if !isempty(capacity_tail_losses)
-        MeanEstimate(capacity_tail_losses)
+function CVAR(unit::Type{U}, x::ShortfallResult{N,L,T,E}, alpha::Float64) where {N,L,T,E,U<:PowerUnit}
+                                    
+    estimate = x.capacity_shortfall_mean[:]
+    var = quantile(estimate, alpha)
+    tail_losses = estimate[estimate .>= var]
+
+    cvar = if !isempty(tail_losses)
+         MeanEstimate(tail_losses)
     else
         MeanEstimate(0.)
     end                                                               
 
-    return CVAR{N,L,T,E}(cvar, alpha, var, capacity_cvar, capacity_var)
+    return CVAR{N,L,T,E}(unit, cvar, alpha, var)
   
 end
 
-function CVAR(x::ShortfallResult{N,L,T,E}, alpha::Float64, r::AbstractString) where {N,L,T,E}
+function CVAR(unit::Type{U}, x::ShortfallResult{N,L,T,E}, alpha::Float64, r::AbstractString) where {N,L,T,E,U<:EnergyUnit}
 
     i_r = findfirstunique(x.regions.names, r)
     estimate = x.shortfall_region_samples[i_r, :]
@@ -350,17 +356,24 @@ function CVAR(x::ShortfallResult{N,L,T,E}, alpha::Float64, r::AbstractString) wh
         MeanEstimate(0.)
     end
 
-    capacity_estimate = x.capacity_shortfall_mean[i_r, :]
-    capacity_var = quantile(capacity_estimate, alpha)
-    capacity_tail_losses = capacity_estimate[capacity_estimate .>= capacity_var]
+    return CVAR{N,L,T,E}(unit, cvar, alpha, var)
+  
+end
 
-    capacity_cvar = if !isempty(capacity_tail_losses)
-        MeanEstimate(capacity_tail_losses)
+function CVAR(unit::Type{U}, x::ShortfallResult{N,L,T,E}, alpha::Float64, r::AbstractString) where {N,L,T,E,U<:PowerUnit}
+
+    i_r = findfirstunique(x.regions.names, r)
+    estimate = x.capacity_shortfall_mean[i_r, :]
+    var = quantile(estimate, alpha)
+    tail_losses = estimate[estimate .>= var]
+
+    cvar = if !isempty(tail_losses)
+        MeanEstimate(tail_losses)
     else
         MeanEstimate(0.)
     end 
 
-    return CVAR{N,L,T,E}(cvar, alpha, var, capacity_cvar, capacity_var)
+    return CVAR{N,L,T,E}(unit, cvar, alpha, var)
   
 end
 

--- a/PRASCore.jl/src/Results/Shortfall.jl
+++ b/PRASCore.jl/src/Results/Shortfall.jl
@@ -180,7 +180,7 @@ struct ShortfallResult{N, L, T <: Period, E <: EnergyUnit, S} <:
         shortfall_regionperiod_std::Matrix{Float64},
         shortfall_samples::Vector{Float64},
         shortfall_region_samples::Matrix{Float64},
-    ) where {N,L,T<:Period,E<:EnergyUnit,S <: Union{Shortfall,DemandResponseShortfall}}
+    ) where {N,L,T<:Period,E<:EnergyUnit,S<:Union{Shortfall,DemandResponseShortfall}}
 
         isnothing(nsamples) || nsamples > 0 ||
             throw(DomainError("Sample count must be positive or `nothing`."))
@@ -270,13 +270,13 @@ end
 EUE(x::ShortfallResult{N,L,T,E}) where {N,L,T,E} =
     EUE{N,L,T,E}(MeanEstimate(x[]..., x.nsamples))
 
-EUE(x::ShortfallResult{N,L,T,E}, r::AbstractString) where {N,L,T,E} =
+EUE(x::ShortfallResult{N,L,T,E},r::AbstractString) where {N,L,T,E} =
     EUE{N,L,T,E}(MeanEstimate(x[r]..., x.nsamples))
 
-EUE(x::ShortfallResult{N,L,T,E}, t::ZonedDateTime) where {N,L,T,E} =
+EUE(x::ShortfallResult{N,L,T,E},t::ZonedDateTime) where {N,L,T,E} =
     EUE{1,L,T,E}(MeanEstimate(x[t]..., x.nsamples))
 
-EUE(x::ShortfallResult{N,L,T,E}, r::AbstractString, t::ZonedDateTime) where {N,L,T,E} =
+EUE(x::ShortfallResult{N,L,T,E},r::AbstractString, t::ZonedDateTime) where {N,L,T,E} =
     EUE{1,L,T,E}(MeanEstimate(x[r, t]..., x.nsamples))
 
 function NEUE(x::ShortfallResult)  
@@ -309,106 +309,47 @@ function NEUE(x::ShortfallResult, r::AbstractString)
 
 end
 
-function CVAR(unit::Type{U}, x::ShortfallResult{N,L,T,E}, alpha::Float64) where {N,L,T,E,U<:EnergyUnit}
-
-    estimate = x.shortfall_samples
-    var = quantile(estimate, alpha)
-    tail_losses = estimate[estimate .>= var]
-
-    cvar = if !isempty(tail_losses)
-        MeanEstimate(tail_losses)
-    else
-        MeanEstimate(0.)
-    end                                                           
-
-    return CVAR{N,L,T,E}(unit, cvar, alpha, var)
-  
+function CVAR(::Val{:energy}, x::ShortfallResult{N,L,T,E},alpha::Float64) where {N,L,T,E}
+    cvar, var = _cvar(x.shortfall_samples, alpha)
+    return CVAR{N,L,T,E}(:energy, cvar, alpha, var)
 end
 
-
-function CVAR(unit::Type{U}, x::ShortfallResult{N,L,T,E}, alpha::Float64, t::StepRange{ZonedDateTime, P}) where {N,L,T,E,U<:EnergyUnit,P}
-
-    i_t0 = findfirstunique(x.timestamps, first(t))
-    i_tf = findlastunique(x.timestamps, last(t))
-    @info "Index for timestamp $t: $i_t0, $i_tf"
-    estimate = x.shortfall_samples[:, i_t0:i_tf]
-    @info "Shortfall samples for timestamp $t: $(estimate)"
-    var = quantile(estimate, alpha)
-    @info "VaR for timestamp $t: $var"
-    tail_losses = estimate[estimate .>= var]
-    @info "Tail losses for timestamp $t: $(tail_losses)"
-
-    cvar = if !isempty(tail_losses)
-        MeanEstimate(tail_losses)
-    else
-        MeanEstimate(0.)
-    end
-
-    return CVAR{N,L,T,E}(unit, cvar, alpha, var)
-  
-end
-
-function CVAR(unit::Type{U}, x::ShortfallResult{N,L,T,E}, alpha::Float64, r::AbstractString) where {N,L,T,E,U<:EnergyUnit}
-
+function CVAR(::Val{:energy}, x::ShortfallResult{N,L,T,E},alpha::Float64, r::AbstractString) where {N,L,T,E}
     i_r = findfirstunique(x.regions.names, r)
-    estimate = x.shortfall_region_samples[i_r, :]
-    var = quantile(estimate, alpha)
-    tail_losses = estimate[estimate .>= var]
-
-    cvar = if !isempty(tail_losses)
-        MeanEstimate(tail_losses)
-    else
-        MeanEstimate(0.)
-    end
-
-    return CVAR{N,L,T,E}(unit, cvar, alpha, var)
-  
+    cvar, var = _cvar(x.shortfall_region_samples[i_r, :], alpha)
+    return CVAR{N,L,T,E}(:energy, cvar, alpha, var)
 end
 
-function CVAR(unit::Type{U}, x::ShortfallResult{N,L,T,E}, alpha::Float64, r::AbstractString, t::ZonedDateTime) where {N,L,T,E,U<:EnergyUnit}
-
-    i_r = findfirstunique(x.regions.names, r)
-    i_t = findfirstunique(x.timestamps, t)
-    estimate = x.shortfall_region_samples[i_r, i_t]
-    var = quantile(estimate, alpha)
-    tail_losses = estimate[estimate .>= var]
-
-    cvar = if !isempty(tail_losses)
-        MeanEstimate(tail_losses)
-    else
-        MeanEstimate(0.)
-    end
-
-    return CVAR{N,L,T,E}(unit, cvar, alpha, var)
-  
+function CVAR(::Val, ::ShortfallResult, ::Float64, ::StepRange{ZonedDateTime})
+    # To support this, add unservedload_period_sample::Matrix{Int} (N × nsamples)
+    # to ShortfallAccumulator, record it in recording.jl, and slice [i_t0:i_tf, :] here.
+    throw(ArgumentError(
+        "Time-sliced CVAR is not supported for ShortfallResult. " *
+        "Use ShortfallSamplesResult instead."))
 end
 
-function NCVAR(x::ShortfallResult{N,L,T,E}, cvar::CVAR) where {N,L,T,E}
+
+function CVAR(::Val, ::ShortfallResult, ::Float64, ::AbstractString, ::ZonedDateTime)
+    # To support this, add unservedload_regionperiod_sample::Array{Int,3} (nregions × N × nsamples)
+    # to ShortfallAccumulator, record it in recording.jl, and slice [i_r, i_t, :] here.
+    throw(ArgumentError(
+        "Region+timestep CVAR is not supported for ShortfallResult. " *
+        "Use ShortfallSamplesResult instead."))
+end
+
+function NCVAR(x::ShortfallResult{N,L,T,E},cvar::CVAR) where {N,L,T,E}
     demand = sum(x.regions.load)
 
-    if demand > 0
-        ncvar = div(cvar.cvar, demand/1e6)
-        var = div(cvar.var, demand/1e6)
-    else
-        ncvar = MeanEstimate(0.)
-        var = MeanEstimate(0.)
-    end
+    ncvar, var = _ncvar(cvar, demand)
 
     return NCVAR(ncvar, cvar.alpha, var)
-  
 end
 
-function NCVAR(x::ShortfallResult{N,L,T,E}, cvar::CVAR, r::AbstractString) where {N,L,T,E}
+function NCVAR(x::ShortfallResult{N,L,T,E},cvar::CVAR, r::AbstractString) where {N,L,T,E}
     i_r = findfirstunique(x.regions.names, r)
     demand = sum(x.regions.load[i_r, :])
 
-    if demand > 0
-        ncvar = div(cvar.cvar, demand/1e6)
-        var = div(cvar.var, demand/1e6)
-    else
-        ncvar = MeanEstimate(0.)
-        var = MeanEstimate(0.)
-    end
+    ncvar, var = _ncvar(cvar, demand)
 
     return NCVAR(ncvar, cvar.alpha, var)
   

--- a/PRASCore.jl/src/Results/Shortfall.jl
+++ b/PRASCore.jl/src/Results/Shortfall.jl
@@ -152,7 +152,6 @@ struct ShortfallResult{N, L, T <: Period, E <: EnergyUnit, S} <:
     eventperiod_regionperiod_std::Matrix{Float64}
 
     shortfall_mean::Matrix{Float64} # r x t
-    capacity_shortfall_mean::Matrix{Float64} # r x t
 
     shortfall_std::Float64
     shortfall_region_std::Vector{Float64}
@@ -175,7 +174,6 @@ struct ShortfallResult{N, L, T <: Period, E <: EnergyUnit, S} <:
         eventperiod_regionperiod_mean::Matrix{Float64},
         eventperiod_regionperiod_std::Matrix{Float64},
         shortfall_mean::Matrix{Float64},
-        capacity_shortfall_mean::Matrix{Float64},
         shortfall_std::Float64,
         shortfall_region_std::Vector{Float64},
         shortfall_period_std::Vector{Float64},
@@ -211,7 +209,7 @@ struct ShortfallResult{N, L, T <: Period, E <: EnergyUnit, S} <:
             eventperiod_region_mean, eventperiod_region_std,
             eventperiod_period_mean, eventperiod_period_std,
             eventperiod_regionperiod_mean, eventperiod_regionperiod_std,
-            shortfall_mean, capacity_shortfall_mean, shortfall_std,
+            shortfall_mean, shortfall_std,
             shortfall_region_std, shortfall_period_std,
             shortfall_regionperiod_std, shortfall_samples,
             shortfall_region_samples)
@@ -396,7 +394,6 @@ function finalize(
     nsamples = first(acc.unservedload_total.stats).n
 
     p2e = conversionfactor(L,T,P,E)
-    capacity_shortfall_mean = ue_regionperiod_mean
     ue_regionperiod_mean .*= p2e
     ue_total_std *= p2e
     ue_region_std .*= p2e
@@ -410,7 +407,7 @@ function finalize(
         ep_total_mean, ep_total_std, ep_region_mean, ep_region_std,
         ep_period_mean, ep_period_std,
         ep_regionperiod_mean, ep_regionperiod_std,
-        ue_regionperiod_mean, capacity_shortfall_mean, ue_total_std,
+        ue_regionperiod_mean, ue_total_std,
         ue_region_std, ue_period_std, ue_regionperiod_std,
         ue_sample, ue_region_sample, )
 

--- a/PRASCore.jl/src/Results/Shortfall.jl
+++ b/PRASCore.jl/src/Results/Shortfall.jl
@@ -327,21 +327,6 @@ function CVAR(unit::Type{U}, x::ShortfallResult{N,L,T,E}, alpha::Float64) where 
   
 end
 
-function CVAR(unit::Type{U}, x::ShortfallResult{N,L,T,E}, alpha::Float64) where {N,L,T,E,U<:PowerUnit}
-                                    
-    estimate = x.capacity_shortfall_mean[:]
-    var = quantile(estimate, alpha)
-    tail_losses = estimate[estimate .>= var]
-
-    cvar = if !isempty(tail_losses)
-         MeanEstimate(tail_losses)
-    else
-        MeanEstimate(0.)
-    end                                                               
-
-    return CVAR{N,L,T,E}(unit, cvar, alpha, var)
-  
-end
 
 function CVAR(unit::Type{U}, x::ShortfallResult{N,L,T,E}, alpha::Float64, r::AbstractString) where {N,L,T,E,U<:EnergyUnit}
 
@@ -355,23 +340,6 @@ function CVAR(unit::Type{U}, x::ShortfallResult{N,L,T,E}, alpha::Float64, r::Abs
     else
         MeanEstimate(0.)
     end
-
-    return CVAR{N,L,T,E}(unit, cvar, alpha, var)
-  
-end
-
-function CVAR(unit::Type{U}, x::ShortfallResult{N,L,T,E}, alpha::Float64, r::AbstractString) where {N,L,T,E,U<:PowerUnit}
-
-    i_r = findfirstunique(x.regions.names, r)
-    estimate = x.capacity_shortfall_mean[i_r, :]
-    var = quantile(estimate, alpha)
-    tail_losses = estimate[estimate .>= var]
-
-    cvar = if !isempty(tail_losses)
-        MeanEstimate(tail_losses)
-    else
-        MeanEstimate(0.)
-    end 
 
     return CVAR{N,L,T,E}(unit, cvar, alpha, var)
   

--- a/PRASCore.jl/src/Results/Shortfall.jl
+++ b/PRASCore.jl/src/Results/Shortfall.jl
@@ -292,6 +292,107 @@ function NEUE(x::ShortfallResult, r::AbstractString)
 
 end
 
+function CVAR(x::ShortfallResult{N,L,T,E}, alpha::Float64) where {N,L,T,E}
+    estimate = x.shortfall_mean[:]
+    var = quantile(estimate, alpha)
+    tail_losses = estimate[estimate .>= var]
+
+    cvar = if !isempty(tail_losses)
+        MeanEstimate(tail_losses)
+    else
+        MeanEstimate(0.)
+    end
+
+    cvar_type = "period"
+
+    return CVAR{N,L,T,E}(cvar, alpha, var, cvar_type)
+  
+end
+
+function CVAR(x::ShortfallResult{N,L,T,E}, alpha::Float64, r::AbstractString) where {N,L,T,E}
+
+    i_r = findfirstunique(x.regions.names, r)
+    estimate = x.shortfall_mean[i_r, :]
+    var = quantile(estimate, alpha)
+    tail_losses = estimate[estimate .>= var]
+
+    cvar = if !isempty(tail_losses)
+        MeanEstimate(tail_losses)
+    else
+        MeanEstimate(0.)
+    end
+
+    cvar_type = "period"
+
+    return CVAR{N,L,T,E}(cvar, alpha, var, cvar_type)
+  
+end
+
+function CVAR(x::ShortfallResult{N,L,T,E}, alpha::Float64, t::ZonedDateTime) where {N,L,T,E}
+    estimate = x.shortfall_mean[t, :]
+    var = quantile(estimate, alpha)
+    tail_losses = estimate[estimate .>= var]
+
+    cvar = if !isempty(tail_losses)
+        MeanEstimate(tail_losses)
+    else
+        MeanEstimate(0.)
+    end
+
+    cvar_type = "period"
+
+    return CVAR{N,L,T,E}(cvar, alpha, var, cvar_type)
+  
+end
+
+function CVAR(x::ShortfallResult{N,L,T,E}, alpha::Float64, r::AbstractString, t::ZonedDateTime) where {N,L,T,E}
+    estimate = x.shortfall_mean[r, t, :]
+    var = quantile(estimate, alpha)
+    tail_losses = estimate[estimate .>= var]
+
+    cvar = if !isempty(tail_losses)
+        MeanEstimate(tail_losses)
+    else
+        MeanEstimate(0.)
+    end
+
+    cvar_type = "period"
+
+    return CVAR{N,L,T,E}(cvar, alpha, var, cvar_type)
+  
+end
+
+function NCVAR(x::ShortfallResult{N,L,T,E}, cvar::CVAR) where {N,L,T,E}
+    demand = sum(x.regions.load)
+
+    if demand > 0
+        ncvar = div(cvar.cvar, demand/1e6)
+        var = div(cvar.var, demand/1e6)
+    else
+        ncvar = MeanEstimate(0.)
+        var = MeanEstimate(0.)
+    end
+
+    return NCVAR(ncvar, cvar.alpha, var)
+  
+end
+
+function NCVAR(x::ShortfallResult{N,L,T,E}, cvar::CVAR, r::AbstractString) where {N,L,T,E}
+    i_r = findfirstunique(x.regions.names, r)
+    demand = sum(x.regions.load[i_r, :])
+
+    if demand > 0
+        ncvar = div(cvar.cvar, demand/1e6)
+        var = div(cvar.var, demand/1e6)
+    else
+        ncvar = MeanEstimate(0.)
+        var = MeanEstimate(0.)
+    end
+
+    return NCVAR(ncvar, cvar.alpha, var)
+  
+end
+
 function finalize(
     acc::ShortfallAccumulator{S},
     system::SystemModel{N,L,T,P,E},

--- a/PRASCore.jl/src/Results/Shortfall.jl
+++ b/PRASCore.jl/src/Results/Shortfall.jl
@@ -67,6 +67,10 @@ mutable struct ShortfallAccumulator{S} <: ResultAccumulator{Shortfall}
     unservedload_total_currentsim::Int
     unservedload_region_currentsim::Vector{Int}
 
+    # Sample-level UE for current simulation
+    unservedload_sample::Union{Vector{Float64}, Vector{Int}}
+    unservedload_region_sample::Union{Matrix{Float64}, Matrix{Int}}
+
 end
 
 function accumulator(
@@ -90,6 +94,8 @@ function accumulator(
 
     unservedload_total_currentsim = 0
     unservedload_region_currentsim = zeros(Int, nregions)
+    unservedload_sample = zeros(Float64, nsamples)
+    unservedload_region_sample = zeros(Float64, nregions, nsamples)
 
     return ShortfallAccumulator{S}(
         periodsdropped_total, periodsdropped_region,
@@ -97,7 +103,8 @@ function accumulator(
         periodsdropped_total_currentsim, periodsdropped_region_currentsim,
         unservedload_total, unservedload_region,
         unservedload_period, unservedload_regionperiod,
-        unservedload_total_currentsim, unservedload_region_currentsim)
+        unservedload_total_currentsim, unservedload_region_currentsim,
+        unservedload_sample, unservedload_region_sample)
 
 end
 
@@ -114,6 +121,9 @@ function merge!(
     foreach(merge!, x.unservedload_region, y.unservedload_region)
     foreach(merge!, x.unservedload_period, y.unservedload_period)
     foreach(merge!, x.unservedload_regionperiod, y.unservedload_regionperiod)
+
+    x.unservedload_sample .+= y.unservedload_sample
+    x.unservedload_region_sample .+= y.unservedload_region_sample
 
     return
 
@@ -149,6 +159,9 @@ struct ShortfallResult{N, L, T <: Period, E <: EnergyUnit, S} <:
     shortfall_period_std::Vector{Float64}
     shortfall_regionperiod_std::Matrix{Float64}
 
+    shortfall_samples::Union{Vector{Float64}, Vector{Int}}
+    shortfall_region_samples::Union{Matrix{Float64}, Matrix{Int}}
+
     function ShortfallResult{N,L,T,E,S}(
         nsamples::Union{Int,Nothing},
         regions::Regions,
@@ -165,7 +178,9 @@ struct ShortfallResult{N, L, T <: Period, E <: EnergyUnit, S} <:
         shortfall_std::Float64,
         shortfall_region_std::Vector{Float64},
         shortfall_period_std::Vector{Float64},
-        shortfall_regionperiod_std::Matrix{Float64}
+        shortfall_regionperiod_std::Matrix{Float64},
+        shortfall_samples::Union{Vector{Float64}, Vector{Int}},
+        shortfall_region_samples::Union{Matrix{Float64}, Matrix{Int}}
     ) where {N,L,T<:Period,E<:EnergyUnit,S <: Union{Shortfall,DemandResponseShortfall}}
 
         isnothing(nsamples) || nsamples > 0 ||
@@ -185,7 +200,9 @@ struct ShortfallResult{N, L, T <: Period, E <: EnergyUnit, S} <:
         size(eventperiod_regionperiod_std) == (nregions, N) &&
         length(shortfall_region_std) == nregions &&
         length(shortfall_period_std) == N &&
-        size(shortfall_regionperiod_std) == (nregions, N) ||
+        size(shortfall_regionperiod_std) == (nregions, N) &&
+        size(shortfall_samples) == (nsamples,) &&
+        size(shortfall_region_samples) == (nregions, nsamples) ||
             error("Inconsistent input data sizes")
 
         new{N,L,T,E,S}(nsamples, regions, timestamps,
@@ -195,7 +212,8 @@ struct ShortfallResult{N, L, T <: Period, E <: EnergyUnit, S} <:
             eventperiod_regionperiod_mean, eventperiod_regionperiod_std,
             shortfall_mean, shortfall_std,
             shortfall_region_std, shortfall_period_std,
-            shortfall_regionperiod_std)
+            shortfall_regionperiod_std, shortfall_samples,
+            shortfall_region_samples)
 
     end
 
@@ -293,7 +311,8 @@ function NEUE(x::ShortfallResult, r::AbstractString)
 end
 
 function CVAR(x::ShortfallResult{N,L,T,E}, alpha::Float64) where {N,L,T,E}
-    estimate = x.shortfall_mean[:]
+
+    estimate = x.shortfall_samples
     var = quantile(estimate, alpha)
     tail_losses = estimate[estimate .>= var]
 
@@ -301,18 +320,26 @@ function CVAR(x::ShortfallResult{N,L,T,E}, alpha::Float64) where {N,L,T,E}
         MeanEstimate(tail_losses)
     else
         MeanEstimate(0.)
-    end
+    end                                                           
 
-    cvar_type = "period"
+    period_estimate = x.shortfall_mean[:]
+    period_var = quantile(period_estimate, alpha)
+    period_tail_losses = period_estimate[period_estimate .>= period_var]
 
-    return CVAR{N,L,T,E}(cvar, alpha, var, cvar_type)
+    period_cvar = if !isempty(period_tail_losses)
+        MeanEstimate(period_tail_losses)
+    else
+        MeanEstimate(0.)
+    end                                                               
+
+    return CVAR{N,L,T,E}(cvar, alpha, var, period_cvar, period_var)
   
 end
 
 function CVAR(x::ShortfallResult{N,L,T,E}, alpha::Float64, r::AbstractString) where {N,L,T,E}
 
     i_r = findfirstunique(x.regions.names, r)
-    estimate = x.shortfall_mean[i_r, :]
+    estimate = x.shortfall_region_samples[i_r, :]
     var = quantile(estimate, alpha)
     tail_losses = estimate[estimate .>= var]
 
@@ -322,43 +349,17 @@ function CVAR(x::ShortfallResult{N,L,T,E}, alpha::Float64, r::AbstractString) wh
         MeanEstimate(0.)
     end
 
-    cvar_type = "period"
+    period_estimate = x.shortfall_mean[i_r, :]
+    period_var = quantile(period_estimate, alpha)
+    period_tail_losses = period_estimate[period_estimate .>= period_var]
 
-    return CVAR{N,L,T,E}(cvar, alpha, var, cvar_type)
-  
-end
-
-function CVAR(x::ShortfallResult{N,L,T,E}, alpha::Float64, t::ZonedDateTime) where {N,L,T,E}
-    estimate = x.shortfall_mean[t, :]
-    var = quantile(estimate, alpha)
-    tail_losses = estimate[estimate .>= var]
-
-    cvar = if !isempty(tail_losses)
-        MeanEstimate(tail_losses)
+    period_cvar = if !isempty(period_tail_losses)
+        MeanEstimate(period_tail_losses)
     else
         MeanEstimate(0.)
-    end
+    end   
 
-    cvar_type = "period"
-
-    return CVAR{N,L,T,E}(cvar, alpha, var, cvar_type)
-  
-end
-
-function CVAR(x::ShortfallResult{N,L,T,E}, alpha::Float64, r::AbstractString, t::ZonedDateTime) where {N,L,T,E}
-    estimate = x.shortfall_mean[r, t, :]
-    var = quantile(estimate, alpha)
-    tail_losses = estimate[estimate .>= var]
-
-    cvar = if !isempty(tail_losses)
-        MeanEstimate(tail_losses)
-    else
-        MeanEstimate(0.)
-    end
-
-    cvar_type = "period"
-
-    return CVAR{N,L,T,E}(cvar, alpha, var, cvar_type)
+    return CVAR{N,L,T,E}(cvar, alpha, var, period_cvar, period_var)
   
 end
 
@@ -418,6 +419,8 @@ function finalize(
     ue_region_std .*= p2e
     ue_period_std .*= p2e
     ue_regionperiod_std .*= p2e
+    ue_sample = acc.unservedload_sample .* p2e
+    ue_region_sample = acc.unservedload_region_sample .* p2e
 
     return ShortfallResult{N,L,T,E,S}(
         nsamples, system.regions, system.timestamps,
@@ -425,6 +428,7 @@ function finalize(
         ep_period_mean, ep_period_std,
         ep_regionperiod_mean, ep_regionperiod_std,
         ue_regionperiod_mean, ue_total_std,
-        ue_region_std, ue_period_std, ue_regionperiod_std)
+        ue_region_std, ue_period_std, ue_regionperiod_std,
+        ue_sample, ue_region_sample)
 
 end

--- a/PRASCore.jl/src/Results/Shortfall.jl
+++ b/PRASCore.jl/src/Results/Shortfall.jl
@@ -326,10 +326,50 @@ function CVAR(unit::Type{U}, x::ShortfallResult{N,L,T,E}, alpha::Float64) where 
 end
 
 
+function CVAR(unit::Type{U}, x::ShortfallResult{N,L,T,E}, alpha::Float64, t::StepRange{ZonedDateTime, P}) where {N,L,T,E,U<:EnergyUnit,P}
+
+    i_t0 = findfirstunique(x.timestamps, first(t))
+    i_tf = findlastunique(x.timestamps, last(t))
+    @info "Index for timestamp $t: $i_t0, $i_tf"
+    estimate = x.shortfall_samples[:, i_t0:i_tf]
+    @info "Shortfall samples for timestamp $t: $(estimate)"
+    var = quantile(estimate, alpha)
+    @info "VaR for timestamp $t: $var"
+    tail_losses = estimate[estimate .>= var]
+    @info "Tail losses for timestamp $t: $(tail_losses)"
+
+    cvar = if !isempty(tail_losses)
+        MeanEstimate(tail_losses)
+    else
+        MeanEstimate(0.)
+    end
+
+    return CVAR{N,L,T,E}(unit, cvar, alpha, var)
+  
+end
+
 function CVAR(unit::Type{U}, x::ShortfallResult{N,L,T,E}, alpha::Float64, r::AbstractString) where {N,L,T,E,U<:EnergyUnit}
 
     i_r = findfirstunique(x.regions.names, r)
     estimate = x.shortfall_region_samples[i_r, :]
+    var = quantile(estimate, alpha)
+    tail_losses = estimate[estimate .>= var]
+
+    cvar = if !isempty(tail_losses)
+        MeanEstimate(tail_losses)
+    else
+        MeanEstimate(0.)
+    end
+
+    return CVAR{N,L,T,E}(unit, cvar, alpha, var)
+  
+end
+
+function CVAR(unit::Type{U}, x::ShortfallResult{N,L,T,E}, alpha::Float64, r::AbstractString, t::ZonedDateTime) where {N,L,T,E,U<:EnergyUnit}
+
+    i_r = findfirstunique(x.regions.names, r)
+    i_t = findfirstunique(x.timestamps, t)
+    estimate = x.shortfall_region_samples[i_r, i_t]
     var = quantile(estimate, alpha)
     tail_losses = estimate[estimate .>= var]
 
@@ -409,6 +449,6 @@ function finalize(
         ep_regionperiod_mean, ep_regionperiod_std,
         ue_regionperiod_mean, ue_total_std,
         ue_region_std, ue_period_std, ue_regionperiod_std,
-        ue_sample, ue_region_sample, )
+        ue_sample, ue_region_sample)
 
 end

--- a/PRASCore.jl/src/Results/Shortfall.jl
+++ b/PRASCore.jl/src/Results/Shortfall.jl
@@ -336,7 +336,7 @@ function CVAR(::Val, ::ShortfallResult, ::Float64, ::AbstractString, ::ZonedDate
         "Use ShortfallSamplesResult instead."))
 end
 
-function NCVAR(x::ShortfallResult{N,L,T,E},cvar::CVAR) where {N,L,T,E}
+function NCVAR(x::ShortfallResult, cvar::CVAR)
     demand = sum(x.regions.load)
 
     ncvar, var = _ncvar(cvar, demand)
@@ -344,7 +344,7 @@ function NCVAR(x::ShortfallResult{N,L,T,E},cvar::CVAR) where {N,L,T,E}
     return NCVAR(cvar.dim, ncvar, cvar.alpha, var)
 end
 
-function NCVAR(x::ShortfallResult{N,L,T,E},cvar::CVAR, r::AbstractString) where {N,L,T,E}
+function NCVAR(x::ShortfallResult, cvar::CVAR, r::AbstractString)
     i_r = findfirstunique(x.regions.names, r)
     demand = sum(x.regions.load[i_r, :])
 

--- a/PRASCore.jl/src/Results/Shortfall.jl
+++ b/PRASCore.jl/src/Results/Shortfall.jl
@@ -68,8 +68,8 @@ mutable struct ShortfallAccumulator{S} <: ResultAccumulator{Shortfall}
     unservedload_region_currentsim::Vector{Int}
 
     # Sample-level UE for current simulation
-    unservedload_sample::Union{Vector{Float64}, Vector{Int}}
-    unservedload_region_sample::Union{Matrix{Float64}, Matrix{Int}}
+    unservedload_sample::Vector{Int}
+    unservedload_region_sample::Matrix{Int}
 
 end
 
@@ -94,8 +94,8 @@ function accumulator(
 
     unservedload_total_currentsim = 0
     unservedload_region_currentsim = zeros(Int, nregions)
-    unservedload_sample = zeros(Float64, nsamples)
-    unservedload_region_sample = zeros(Float64, nregions, nsamples)
+    unservedload_sample = zeros(Int, nsamples)
+    unservedload_region_sample = zeros(Int, nregions, nsamples)
 
     return ShortfallAccumulator{S}(
         periodsdropped_total, periodsdropped_region,
@@ -151,16 +151,16 @@ struct ShortfallResult{N, L, T <: Period, E <: EnergyUnit, S} <:
     eventperiod_regionperiod_mean::Matrix{Float64}
     eventperiod_regionperiod_std::Matrix{Float64}
 
-
     shortfall_mean::Matrix{Float64} # r x t
+    capacity_shortfall_mean::Matrix{Float64} # r x t
 
     shortfall_std::Float64
     shortfall_region_std::Vector{Float64}
     shortfall_period_std::Vector{Float64}
     shortfall_regionperiod_std::Matrix{Float64}
 
-    shortfall_samples::Union{Vector{Float64}, Vector{Int}}
-    shortfall_region_samples::Union{Matrix{Float64}, Matrix{Int}}
+    shortfall_samples::Vector{Float64}
+    shortfall_region_samples::Matrix{Float64}
 
     function ShortfallResult{N,L,T,E,S}(
         nsamples::Union{Int,Nothing},
@@ -175,12 +175,13 @@ struct ShortfallResult{N, L, T <: Period, E <: EnergyUnit, S} <:
         eventperiod_regionperiod_mean::Matrix{Float64},
         eventperiod_regionperiod_std::Matrix{Float64},
         shortfall_mean::Matrix{Float64},
+        capacity_shortfall_mean::Matrix{Float64},
         shortfall_std::Float64,
         shortfall_region_std::Vector{Float64},
         shortfall_period_std::Vector{Float64},
         shortfall_regionperiod_std::Matrix{Float64},
-        shortfall_samples::Union{Vector{Float64}, Vector{Int}},
-        shortfall_region_samples::Union{Matrix{Float64}, Matrix{Int}}
+        shortfall_samples::Vector{Float64},
+        shortfall_region_samples::Matrix{Float64},
     ) where {N,L,T<:Period,E<:EnergyUnit,S <: Union{Shortfall,DemandResponseShortfall}}
 
         isnothing(nsamples) || nsamples > 0 ||
@@ -210,7 +211,7 @@ struct ShortfallResult{N, L, T <: Period, E <: EnergyUnit, S} <:
             eventperiod_region_mean, eventperiod_region_std,
             eventperiod_period_mean, eventperiod_period_std,
             eventperiod_regionperiod_mean, eventperiod_regionperiod_std,
-            shortfall_mean, shortfall_std,
+            shortfall_mean, capacity_shortfall_mean, shortfall_std,
             shortfall_region_std, shortfall_period_std,
             shortfall_regionperiod_std, shortfall_samples,
             shortfall_region_samples)
@@ -322,17 +323,17 @@ function CVAR(x::ShortfallResult{N,L,T,E}, alpha::Float64) where {N,L,T,E}
         MeanEstimate(0.)
     end                                                           
 
-    period_estimate = x.shortfall_mean[:]
-    period_var = quantile(period_estimate, alpha)
-    period_tail_losses = period_estimate[period_estimate .>= period_var]
+    capacity_estimate = x.capacity_shortfall_mean[:]
+    capacity_var = quantile(capacity_estimate, alpha)
+    capacity_tail_losses = capacity_estimate[capacity_estimate .>= capacity_var]
 
-    period_cvar = if !isempty(period_tail_losses)
-        MeanEstimate(period_tail_losses)
+    capacity_cvar = if !isempty(capacity_tail_losses)
+        MeanEstimate(capacity_tail_losses)
     else
         MeanEstimate(0.)
     end                                                               
 
-    return CVAR{N,L,T,E}(cvar, alpha, var, period_cvar, period_var)
+    return CVAR{N,L,T,E}(cvar, alpha, var, capacity_cvar, capacity_var)
   
 end
 
@@ -349,17 +350,17 @@ function CVAR(x::ShortfallResult{N,L,T,E}, alpha::Float64, r::AbstractString) wh
         MeanEstimate(0.)
     end
 
-    period_estimate = x.shortfall_mean[i_r, :]
-    period_var = quantile(period_estimate, alpha)
-    period_tail_losses = period_estimate[period_estimate .>= period_var]
+    capacity_estimate = x.capacity_shortfall_mean[i_r, :]
+    capacity_var = quantile(capacity_estimate, alpha)
+    capacity_tail_losses = capacity_estimate[capacity_estimate .>= capacity_var]
 
-    period_cvar = if !isempty(period_tail_losses)
-        MeanEstimate(period_tail_losses)
+    capacity_cvar = if !isempty(capacity_tail_losses)
+        MeanEstimate(capacity_tail_losses)
     else
         MeanEstimate(0.)
-    end   
+    end 
 
-    return CVAR{N,L,T,E}(cvar, alpha, var, period_cvar, period_var)
+    return CVAR{N,L,T,E}(cvar, alpha, var, capacity_cvar, capacity_var)
   
 end
 
@@ -414,21 +415,22 @@ function finalize(
     nsamples = first(acc.unservedload_total.stats).n
 
     p2e = conversionfactor(L,T,P,E)
+    capacity_shortfall_mean = ue_regionperiod_mean
     ue_regionperiod_mean .*= p2e
     ue_total_std *= p2e
     ue_region_std .*= p2e
     ue_period_std .*= p2e
     ue_regionperiod_std .*= p2e
-    ue_sample = acc.unservedload_sample .* p2e
-    ue_region_sample = acc.unservedload_region_sample .* p2e
+    ue_sample = float(acc.unservedload_sample .* p2e)
+    ue_region_sample = float(acc.unservedload_region_sample .* p2e)
 
     return ShortfallResult{N,L,T,E,S}(
         nsamples, system.regions, system.timestamps,
         ep_total_mean, ep_total_std, ep_region_mean, ep_region_std,
         ep_period_mean, ep_period_std,
         ep_regionperiod_mean, ep_regionperiod_std,
-        ue_regionperiod_mean, ue_total_std,
+        ue_regionperiod_mean, capacity_shortfall_mean, ue_total_std,
         ue_region_std, ue_period_std, ue_regionperiod_std,
-        ue_sample, ue_region_sample)
+        ue_sample, ue_region_sample, )
 
 end

--- a/PRASCore.jl/src/Results/Shortfall.jl
+++ b/PRASCore.jl/src/Results/Shortfall.jl
@@ -328,7 +328,6 @@ function CVAR(::Val, ::ShortfallResult, ::Float64, ::StepRange{ZonedDateTime})
         "Use ShortfallSamplesResult instead."))
 end
 
-
 function CVAR(::Val, ::ShortfallResult, ::Float64, ::AbstractString, ::ZonedDateTime)
     # To support this, add unservedload_regionperiod_sample::Array{Int,3} (nregions × N × nsamples)
     # to ShortfallAccumulator, record it in recording.jl, and slice [i_r, i_t, :] here.
@@ -342,7 +341,7 @@ function NCVAR(x::ShortfallResult{N,L,T,E},cvar::CVAR) where {N,L,T,E}
 
     ncvar, var = _ncvar(cvar, demand)
 
-    return NCVAR(ncvar, cvar.alpha, var)
+    return NCVAR(cvar.dim, ncvar, cvar.alpha, var)
 end
 
 function NCVAR(x::ShortfallResult{N,L,T,E},cvar::CVAR, r::AbstractString) where {N,L,T,E}
@@ -351,7 +350,7 @@ function NCVAR(x::ShortfallResult{N,L,T,E},cvar::CVAR, r::AbstractString) where 
 
     ncvar, var = _ncvar(cvar, demand)
 
-    return NCVAR(ncvar, cvar.alpha, var)
+    return NCVAR(cvar.dim, ncvar, cvar.alpha, var)
   
 end
 

--- a/PRASCore.jl/src/Results/ShortfallSamples.jl
+++ b/PRASCore.jl/src/Results/ShortfallSamples.jl
@@ -186,9 +186,10 @@ function NEUE(x::ShortfallSamplesResult, r::AbstractString)
 end
 
 function CVAR(x::ShortfallSamplesResult{N,L,T,P,E}, alpha::Float64) where {N,L,T,P,E}
+    
     estimate = x[]
     var = quantile(estimate, alpha)
-    tail_losses = estimate[estimate .>= var]
+    tail_losses = estimate[estimate .> var]
 
     cvar = if !isempty(tail_losses)
         MeanEstimate(tail_losses)
@@ -196,9 +197,18 @@ function CVAR(x::ShortfallSamplesResult{N,L,T,P,E}, alpha::Float64) where {N,L,T
         MeanEstimate(0.)
     end
 
-    cvar_type = "sample"
+    period_estimate = x.shortfall[:]
+    period_var = quantile(period_estimate, alpha)
+    period_tail_losses = period_estimate[period_estimate .>= period_var]
+
+    period_cvar = if !isempty(period_tail_losses)
+        MeanEstimate(period_tail_losses)
+    else
+        MeanEstimate(0.)
+    end     
+
     
-    return CVAR{N,L,T,E}(cvar, alpha, var, cvar_type)
+    return CVAR{N,L,T,E}(cvar, alpha, var, period_cvar, period_var)
 
 end
 
@@ -213,9 +223,18 @@ function CVAR(x::ShortfallSamplesResult{N,L,T,P,E}, alpha::Float64, r::AbstractS
         MeanEstimate(0.)
     end
     
-    cvar_type = "sample"
+    i_r = findfirstunique(x.regions.names, r)
+    period_estimate = x.shortfall[i_r, :, :][:]
+    period_var = quantile(period_estimate, alpha)
+    period_tail_losses = period_estimate[period_estimate .>= period_var]
 
-    return CVAR{N,L,T,E}(cvar, alpha, var, cvar_type)
+    period_cvar = if !isempty(period_tail_losses)
+        MeanEstimate(period_tail_losses)
+    else
+        MeanEstimate(0.)
+    end  
+
+    return CVAR{N,L,T,E}(cvar, alpha, var, period_cvar, period_var)
 
 end
 
@@ -229,10 +248,8 @@ function CVAR(x::ShortfallSamplesResult{N,L,T,P,E}, alpha::Float64, t::ZonedDate
     else
         MeanEstimate(0.)
     end
-    
-    cvar_type = "sample"
-    
-    return CVAR{N,L,T,E}(cvar, alpha, var, cvar_type)
+
+    return CVAR{N,L,T,E}(cvar, alpha, var, cvar, var)
 
 end
 
@@ -247,9 +264,7 @@ function CVAR(x::ShortfallSamplesResult{N,L,T,P,E}, alpha::Float64, r::AbstractS
         MeanEstimate(0.)
     end
     
-    cvar_type = "sample"
-
-    return CVAR{N,L,T,E}(cvar, alpha, var, cvar_type)
+    return CVAR{N,L,T,E}(cvar, alpha, var, cvar, var)
 end
 
 function NCVAR(x::ShortfallSamplesResult{N,L,T,P}, cvar::CVAR) where {N,L,T,P}

--- a/PRASCore.jl/src/Results/ShortfallSamples.jl
+++ b/PRASCore.jl/src/Results/ShortfallSamples.jl
@@ -82,7 +82,6 @@ struct ShortfallSamplesResult{N,L,T<:Period,P<:PowerUnit,E<:EnergyUnit, S} <: Ab
     timestamps::StepRange{ZonedDateTime,T}
 
     shortfall::Array{Int,3} # r x t x s
-    capacity_shortfall::Array{Float64,2} # r x s
 
 end
 
@@ -282,10 +281,7 @@ function finalize(
     system::SystemModel{N,L,T,P,E},
 ) where {N,L,T,P,E,S<:Union{ShortfallSamples,DemandResponseShortfallSamples}}
 
-    n_regions = length(system.regions)
-    p2e = conversionfactor(L,T,P,E)
-    max_capacity_shortfall = reshape(maximum(acc.shortfall, dims=[2]) ./ p2e, n_regions, :)
     return ShortfallSamplesResult{N,L,T,P,E,S}(
-        system.regions, system.timestamps, acc.shortfall, max_capacity_shortfall)
+        system.regions, system.timestamps, acc.shortfall)
 
 end

--- a/PRASCore.jl/src/Results/ShortfallSamples.jl
+++ b/PRASCore.jl/src/Results/ShortfallSamples.jl
@@ -241,48 +241,30 @@ function CVAR(x::ShortfallSamplesResult{N,L,T,P,E}, alpha::Float64, r::AbstractS
 
 end
 
-function NCVAR(x::ShortfallSamplesResult{N,L,T,P}, alpha::Float64) where {N,L,T,P}
+function NCVAR(x::ShortfallSamplesResult{N,L,T,P}, cvar::CVAR) where {N,L,T,P}
     demand = sum(x.regions.load)
 
-    estimate = x[]
-    tail_losses = estimate[estimate .>= quantile(estimate, alpha)]
-
-    cvar = if !isempty(tail_losses)
-        MeanEstimate(tail_losses)
-    else
-        MeanEstimate(0.)
-    end
-
     ncvar = if demand > 0
-        div(cvar, demand/1e6)
+        div(cvar.cvar, demand/1e6)
     else
         MeanEstimate(0.)
     end
 
-    return NCVAR{N,L,T}(ncvar, alpha)
+    return NCVAR(ncvar, cvar.alpha)
 
 end
 
-function NCVAR(x::ShortfallSamplesResult{N,L,T,P}, alpha::Float64, r::AbstractString) where {N,L,T,P}
+function NCVAR(x::ShortfallSamplesResult{N,L,T,P}, cvar::CVAR, r::AbstractString) where {N,L,T,P}
     i_r = findfirstunique(x.regions.names, r)
     demand = sum(x.regions.load[i_r, :])
 
-    estimate = x[r]
-    tail_losses = estimate[estimate .>= quantile(estimate, alpha)]
-
-    cvar = if !isempty(tail_losses)
-        MeanEstimate(tail_losses)
-    else
-        MeanEstimate(0.)
-    end
-
     ncvar = if demand > 0
-        div(cvar, demand/1e6)
+        div(cvar.cvar, demand/1e6)
     else
         MeanEstimate(0.)
     end
     
-    return NCVAR{N,L,T}(ncvar, alpha)
+    return NCVAR(ncvar, cvar.alpha)
 
 end
 

--- a/PRASCore.jl/src/Results/ShortfallSamples.jl
+++ b/PRASCore.jl/src/Results/ShortfallSamples.jl
@@ -117,6 +117,25 @@ function getindex(
     return vec(p2e * x.shortfall[i_r, i_t, :])
 end
 
+function getindex(
+    x::ShortfallSamplesResult{N,L,T,P,E}, t::StepRange{ZonedDateTime}
+) where {N,L,T,P,E}
+    i_t0 = findfirstunique(x.timestamps, first(t))
+    i_tf = findlastunique(x.timestamps, last(t))
+    p2e = conversionfactor(L, T, P, E)
+    return vec(p2e * sum(x.shortfall[:, i_t0:i_tf, :], dims=1:2))
+end
+
+function getindex(
+    x::ShortfallSamplesResult{N,L,T,P,E}, r::AbstractString, t::StepRange{ZonedDateTime}
+) where {N,L,T,P,E}
+    i_r = findfirstunique(x.regions.names, r)
+    i_t0 = findfirstunique(x.timestamps, first(t))
+    i_tf = findlastunique(x.timestamps, last(t))
+    p2e = conversionfactor(L, T, P, E)
+    return vec(p2e * sum(x.shortfall[i_r, i_t0:i_tf, :], dims=1))
+end
+
 
 function LOLE(x::ShortfallSamplesResult{N,L,T}) where {N,L,T}
     eventperiods = sum(sum(x.shortfall, dims=1) .> 0, dims=2)
@@ -185,76 +204,35 @@ function NEUE(x::ShortfallSamplesResult, r::AbstractString)
 
 end
 
-function CVAR(unit::Type{U}, x::ShortfallSamplesResult{N,L,T,P,E}, alpha::Float64) where {N,L,T,P,E,U<:EnergyUnit}
-    
-    estimate = x[]
-    var = quantile(estimate, alpha)
-    tail_losses = estimate[estimate .>= var]
-
-    cvar = if !isempty(tail_losses)
-        MeanEstimate(tail_losses)
-    else
-        MeanEstimate(0.)
-    end
-
-    return CVAR{N,L,T,E}(unit, cvar, alpha, var)
-
+function CVAR(::Val{:energy}, x::ShortfallSamplesResult{N,L,T,P,E}, alpha::Float64) where {N,L,T,P,E}
+    cvar, var = _cvar(x[], alpha)
+    return CVAR{N,L,T,E}(:energy, cvar, alpha, var)
 end
 
-function CVAR(unit::Type{U}, x::ShortfallSamplesResult{N,L,T,P,E}, alpha::Float64, r::AbstractString) where {N,L,T,P,E,U<:EnergyUnit}
-    estimate = x[r]
-    var = quantile(estimate, alpha)
-    tail_losses = estimate[estimate .>= var]
-
-    cvar = if !isempty(tail_losses)
-        MeanEstimate(tail_losses)
-    else
-        MeanEstimate(0.)
-    end
-
-    return CVAR{N,L,T,E}(unit, cvar, alpha, var)
-
+function CVAR(::Val{:energy}, x::ShortfallSamplesResult{N,L,T,P,E}, alpha::Float64, r::AbstractString) where {N,L,T,P,E}
+    cvar, var = _cvar(x[r], alpha)
+    return CVAR{N,L,T,E}(:energy, cvar, alpha, var)
 end
 
-function CVAR(unit::Type{U}, x::ShortfallSamplesResult{N,L,T,P,E}, alpha::Float64, t::ZonedDateTime) where {N,L,T,P,E,U<:EnergyUnit}
-    estimate = x[t]
-    var = quantile(estimate, alpha)
-    tail_losses = estimate[estimate .>= var]
-
-    cvar = if !isempty(tail_losses)
-        MeanEstimate(tail_losses)
-    else
-        MeanEstimate(0.)
-    end
-
-    return CVAR{N,L,T,E}(unit, cvar, alpha, var)
-
+function CVAR(::Val{:energy}, x::ShortfallSamplesResult{N,L,T,P,E}, alpha::Float64, t::StepRange{ZonedDateTime}) where {N,L,T,P,E}
+    cvar, var = _cvar(x[t], alpha)
+    return CVAR{N,L,T,E}(:energy, cvar, alpha, var)
 end
 
-function CVAR(unit::Type{U}, x::ShortfallSamplesResult{N,L,T,P,E}, alpha::Float64, r::AbstractString, t::ZonedDateTime) where {N,L,T,P,E,U<:EnergyUnit}
-    estimate = x[r, t]
-    var = quantile(estimate, alpha)
-    tail_losses = estimate[estimate .>= var]
+function CVAR(::Val{:energy}, x::ShortfallSamplesResult{N,L,T,P,E}, alpha::Float64, r::AbstractString, t::ZonedDateTime) where {N,L,T,P,E}
+    cvar, var = _cvar(x[r, t], alpha)
+    return CVAR{N,L,T,E}(:energy, cvar, alpha, var)
+end
 
-    cvar = if !isempty(tail_losses)
-        MeanEstimate(tail_losses)
-    else
-        MeanEstimate(0.)
-    end
-    
-    return CVAR{N,L,T,E}(unit, cvar, alpha, var)
+function CVAR(::Val{:energy}, x::ShortfallSamplesResult{N,L,T,P,E}, alpha::Float64, r::AbstractString, t::StepRange{ZonedDateTime}) where {N,L,T,P,E}
+    cvar, var = _cvar(x[r, t], alpha)
+    return CVAR{N,L,T,E}(:energy, cvar, alpha, var)
 end
 
 function NCVAR(x::ShortfallSamplesResult{N,L,T,P}, cvar::CVAR) where {N,L,T,P}
     demand = sum(x.regions.load)
 
-    if demand > 0
-        ncvar = div(cvar.cvar, demand/1e6)
-        var = div(cvar.var, demand/1e6)
-    else
-        ncvar = MeanEstimate(0.)
-        var = MeanEstimate(0.)
-    end
+    ncvar, var = _ncvar(cvar, demand)
 
     return NCVAR(ncvar, cvar.alpha, var)
 
@@ -264,14 +242,7 @@ function NCVAR(x::ShortfallSamplesResult{N,L,T,P}, cvar::CVAR, r::AbstractString
     i_r = findfirstunique(x.regions.names, r)
     demand = sum(x.regions.load[i_r, :])
 
-    if demand > 0
-        ncvar = div(cvar.cvar, demand/1e6)
-        var = div(cvar.var, demand/1e6)
-    else
-        ncvar = MeanEstimate(0.)
-        var = MeanEstimate(0.)
-    end
-    
+    ncvar, var = _ncvar(cvar, demand)
     return NCVAR(ncvar, cvar.alpha, var)
 
 end

--- a/PRASCore.jl/src/Results/ShortfallSamples.jl
+++ b/PRASCore.jl/src/Results/ShortfallSamples.jl
@@ -187,21 +187,25 @@ end
 
 function CVAR(x::ShortfallSamplesResult{N,L,T,P,E}, alpha::Float64) where {N,L,T,P,E}
     estimate = x[]
-    tail_losses = estimate[estimate .>= quantile(estimate, alpha)]
+    var = quantile(estimate, alpha)
+    tail_losses = estimate[estimate .>= var]
 
     cvar = if !isempty(tail_losses)
         MeanEstimate(tail_losses)
     else
         MeanEstimate(0.)
     end
+
+    cvar_type = "sample"
     
-    return CVAR{N,L,T,E}(cvar, alpha)
+    return CVAR{N,L,T,E}(cvar, alpha, var, cvar_type)
 
 end
 
 function CVAR(x::ShortfallSamplesResult{N,L,T,P,E}, alpha::Float64, r::AbstractString) where {N,L,T,P,E}
     estimate = x[r]
-    tail_losses = estimate[estimate .>= quantile(estimate, alpha)]
+    var = quantile(estimate, alpha)
+    tail_losses = estimate[estimate .>= var]
 
     cvar = if !isempty(tail_losses)
         MeanEstimate(tail_losses)
@@ -209,13 +213,16 @@ function CVAR(x::ShortfallSamplesResult{N,L,T,P,E}, alpha::Float64, r::AbstractS
         MeanEstimate(0.)
     end
     
-    return CVAR{N,L,T,E}(cvar, alpha)
+    cvar_type = "sample"
+
+    return CVAR{N,L,T,E}(cvar, alpha, var, cvar_type)
 
 end
 
 function CVAR(x::ShortfallSamplesResult{N,L,T,P,E}, alpha::Float64, t::ZonedDateTime) where {N,L,T,P,E}
     estimate = x[t]
-    tail_losses = estimate[estimate .>= quantile(estimate, alpha)]
+    var = quantile(estimate, alpha)
+    tail_losses = estimate[estimate .>= var]
 
     cvar = if !isempty(tail_losses)
         MeanEstimate(tail_losses)
@@ -223,13 +230,16 @@ function CVAR(x::ShortfallSamplesResult{N,L,T,P,E}, alpha::Float64, t::ZonedDate
         MeanEstimate(0.)
     end
     
-    return CVAR{N,L,T,E}(cvar, alpha)
+    cvar_type = "sample"
+    
+    return CVAR{N,L,T,E}(cvar, alpha, var, cvar_type)
 
 end
 
 function CVAR(x::ShortfallSamplesResult{N,L,T,P,E}, alpha::Float64, r::AbstractString, t::ZonedDateTime) where {N,L,T,P,E}
     estimate = x[r, t]
-    tail_losses = estimate[estimate .>= quantile(estimate, alpha)]
+    var = quantile(estimate, alpha)
+    tail_losses = estimate[estimate .>= var]
 
     cvar = if !isempty(tail_losses)
         MeanEstimate(tail_losses)
@@ -237,20 +247,23 @@ function CVAR(x::ShortfallSamplesResult{N,L,T,P,E}, alpha::Float64, r::AbstractS
         MeanEstimate(0.)
     end
     
-    return CVAR{N,L,T,E}(cvar, alpha)
+    cvar_type = "sample"
 
+    return CVAR{N,L,T,E}(cvar, alpha, var, cvar_type)
 end
 
 function NCVAR(x::ShortfallSamplesResult{N,L,T,P}, cvar::CVAR) where {N,L,T,P}
     demand = sum(x.regions.load)
 
-    ncvar = if demand > 0
-        div(cvar.cvar, demand/1e6)
+    if demand > 0
+        ncvar = div(cvar.cvar, demand/1e6)
+        var = div(cvar.var, demand/1e6)
     else
-        MeanEstimate(0.)
+        ncvar = MeanEstimate(0.)
+        var = MeanEstimate(0.)
     end
 
-    return NCVAR(ncvar, cvar.alpha)
+    return NCVAR(ncvar, cvar.alpha, var)
 
 end
 
@@ -258,13 +271,15 @@ function NCVAR(x::ShortfallSamplesResult{N,L,T,P}, cvar::CVAR, r::AbstractString
     i_r = findfirstunique(x.regions.names, r)
     demand = sum(x.regions.load[i_r, :])
 
-    ncvar = if demand > 0
-        div(cvar.cvar, demand/1e6)
+    if demand > 0
+        ncvar = div(cvar.cvar, demand/1e6)
+        var = div(cvar.var, demand/1e6)
     else
-        MeanEstimate(0.)
+        ncvar = MeanEstimate(0.)
+        var = MeanEstimate(0.)
     end
     
-    return NCVAR(ncvar, cvar.alpha)
+    return NCVAR(ncvar, cvar.alpha, var)
 
 end
 

--- a/PRASCore.jl/src/Results/ShortfallSamples.jl
+++ b/PRASCore.jl/src/Results/ShortfallSamples.jl
@@ -240,6 +240,52 @@ function CVAR(x::ShortfallSamplesResult{N,L,T,P,E}, alpha::Float64, r::AbstractS
     return CVAR{N,L,T,E}(cvar, alpha)
 
 end
+
+function NCVAR(x::ShortfallSamplesResult{N,L,T,P}, alpha::Float64) where {N,L,T,P}
+    demand = sum(x.regions.load)
+
+    estimate = x[]
+    tail_losses = estimate[estimate .>= quantile(estimate, alpha)]
+
+    cvar = if !isempty(tail_losses)
+        MeanEstimate(tail_losses)
+    else
+        MeanEstimate(0.)
+    end
+
+    ncvar = if demand > 0
+        div(cvar, demand/1e6)
+    else
+        MeanEstimate(0.)
+    end
+
+    return NCVAR{N,L,T}(ncvar, alpha)
+
+end
+
+function NCVAR(x::ShortfallSamplesResult{N,L,T,P}, alpha::Float64, r::AbstractString) where {N,L,T,P}
+    i_r = findfirstunique(x.regions.names, r)
+    demand = sum(x.regions.load[i_r, :])
+
+    estimate = x[r]
+    tail_losses = estimate[estimate .>= quantile(estimate, alpha)]
+
+    cvar = if !isempty(tail_losses)
+        MeanEstimate(tail_losses)
+    else
+        MeanEstimate(0.)
+    end
+
+    ncvar = if demand > 0
+        div(cvar, demand/1e6)
+    else
+        MeanEstimate(0.)
+    end
+    
+    return NCVAR{N,L,T}(ncvar, alpha)
+
+end
+
 function finalize(
     acc::ShortfallSamplesAccumulator{S},
     system::SystemModel{N,L,T,P,E},

--- a/PRASCore.jl/src/Results/ShortfallSamples.jl
+++ b/PRASCore.jl/src/Results/ShortfallSamples.jl
@@ -186,7 +186,7 @@ function NEUE(x::ShortfallSamplesResult, r::AbstractString)
 
 end
 
-function CVAR(x::ShortfallSamplesResult{N,L,T,P,E}, alpha::Float64) where {N,L,T,P,E}
+function CVAR(unit::Type{U}, x::ShortfallSamplesResult{N,L,T,P,E}, alpha::Float64) where {N,L,T,P,E,U<:EnergyUnit}
     
     estimate = x[]
     var = quantile(estimate, alpha)
@@ -198,21 +198,11 @@ function CVAR(x::ShortfallSamplesResult{N,L,T,P,E}, alpha::Float64) where {N,L,T
         MeanEstimate(0.)
     end
 
-    # capacity_estimate = x.capacity_shortfall[:]
-    # capacity_var = quantile(capacity_estimate, alpha)
-    # capacity_tail_losses = capacity_estimate[capacity_estimate .>= capacity_var]
-
-    # capacity_cvar = if !isempty(capacity_tail_losses)
-    #     MeanEstimate(capacity_tail_losses)
-    # else
-    #     MeanEstimate(0.)
-    # end     
-
-    return CVAR{N,L,T,E}(cvar, alpha, var)
+    return CVAR{N,L,T,E}(unit, cvar, alpha, var)
 
 end
 
-function CVAR(x::ShortfallSamplesResult{N,L,T,P,E}, alpha::Float64, r::AbstractString) where {N,L,T,P,E}
+function CVAR(unit::Type{U}, x::ShortfallSamplesResult{N,L,T,P,E}, alpha::Float64, r::AbstractString) where {N,L,T,P,E,U<:EnergyUnit}
     estimate = x[r]
     var = quantile(estimate, alpha)
     tail_losses = estimate[estimate .>= var]
@@ -222,23 +212,12 @@ function CVAR(x::ShortfallSamplesResult{N,L,T,P,E}, alpha::Float64, r::AbstractS
     else
         MeanEstimate(0.)
     end
-    
-    # i_r = findfirstunique(x.regions.names, r)
-    # capacity_estimate = x.capacity_shortfall[i_r, :]
-    # capacity_var = quantile(capacity_estimate, alpha)
-    # capacity_tail_losses = capacity_estimate[capacity_estimate .>= capacity_var]
 
-    # capacity_cvar = if !isempty(capacity_tail_losses)
-    #     MeanEstimate(capacity_tail_losses)
-    # else
-    #     MeanEstimate(0.)
-    # end     
-
-    return CVAR{N,L,T,E}(cvar, alpha, var)
+    return CVAR{N,L,T,E}(unit, cvar, alpha, var)
 
 end
 
-function CVAR(x::ShortfallSamplesResult{N,L,T,P,E}, alpha::Float64, t::ZonedDateTime) where {N,L,T,P,E}
+function CVAR(unit::Type{U}, x::ShortfallSamplesResult{N,L,T,P,E}, alpha::Float64, t::ZonedDateTime) where {N,L,T,P,E,U<:EnergyUnit}
     estimate = x[t]
     var = quantile(estimate, alpha)
     tail_losses = estimate[estimate .>= var]
@@ -249,11 +228,11 @@ function CVAR(x::ShortfallSamplesResult{N,L,T,P,E}, alpha::Float64, t::ZonedDate
         MeanEstimate(0.)
     end
 
-    return CVAR{N,L,T,E}(cvar, alpha, var, cvar, var)
+    return CVAR{N,L,T,E}(unit, cvar, alpha, var)
 
 end
 
-function CVAR(x::ShortfallSamplesResult{N,L,T,P,E}, alpha::Float64, r::AbstractString, t::ZonedDateTime) where {N,L,T,P,E}
+function CVAR(unit::Type{U}, x::ShortfallSamplesResult{N,L,T,P,E}, alpha::Float64, r::AbstractString, t::ZonedDateTime) where {N,L,T,P,E,U<:EnergyUnit}
     estimate = x[r, t]
     var = quantile(estimate, alpha)
     tail_losses = estimate[estimate .>= var]
@@ -264,7 +243,7 @@ function CVAR(x::ShortfallSamplesResult{N,L,T,P,E}, alpha::Float64, r::AbstractS
         MeanEstimate(0.)
     end
     
-    return CVAR{N,L,T,E}(cvar, alpha, var, cvar, var)
+    return CVAR{N,L,T,E}(unit, cvar, alpha, var)
 end
 
 function NCVAR(x::ShortfallSamplesResult{N,L,T,P}, cvar::CVAR) where {N,L,T,P}

--- a/PRASCore.jl/src/Results/ShortfallSamples.jl
+++ b/PRASCore.jl/src/Results/ShortfallSamples.jl
@@ -82,7 +82,7 @@ struct ShortfallSamplesResult{N,L,T<:Period,P<:PowerUnit,E<:EnergyUnit, S} <: Ab
     timestamps::StepRange{ZonedDateTime,T}
 
     shortfall::Array{Int,3} # r x t x s
-    capacity_shortfall::Array{Int,2} # r x s
+    capacity_shortfall::Array{Float64,2} # r x s
 
 end
 

--- a/PRASCore.jl/src/Results/ShortfallSamples.jl
+++ b/PRASCore.jl/src/Results/ShortfallSamples.jl
@@ -185,6 +185,61 @@ function NEUE(x::ShortfallSamplesResult, r::AbstractString)
 
 end
 
+function CVAR(x::ShortfallSamplesResult{N,L,T,P,E}, alpha::Float64) where {N,L,T,P,E}
+    estimate = x[]
+    tail_losses = estimate[estimate .>= quantile(estimate, alpha)]
+
+    cvar = if !isempty(tail_losses)
+        MeanEstimate(tail_losses)
+    else
+        MeanEstimate(0.)
+    end
+    
+    return CVAR{N,L,T,E}(cvar, alpha)
+
+end
+
+function CVAR(x::ShortfallSamplesResult{N,L,T,P,E}, alpha::Float64, r::AbstractString) where {N,L,T,P,E}
+    estimate = x[r]
+    tail_losses = estimate[estimate .>= quantile(estimate, alpha)]
+
+    cvar = if !isempty(tail_losses)
+        MeanEstimate(tail_losses)
+    else
+        MeanEstimate(0.)
+    end
+    
+    return CVAR{N,L,T,E}(cvar, alpha)
+
+end
+
+function CVAR(x::ShortfallSamplesResult{N,L,T,P,E}, alpha::Float64, t::ZonedDateTime) where {N,L,T,P,E}
+    estimate = x[t]
+    tail_losses = estimate[estimate .>= quantile(estimate, alpha)]
+
+    cvar = if !isempty(tail_losses)
+        MeanEstimate(tail_losses)
+    else
+        MeanEstimate(0.)
+    end
+    
+    return CVAR{N,L,T,E}(cvar, alpha)
+
+end
+
+function CVAR(x::ShortfallSamplesResult{N,L,T,P,E}, alpha::Float64, r::AbstractString, t::ZonedDateTime) where {N,L,T,P,E}
+    estimate = x[r, t]
+    tail_losses = estimate[estimate .>= quantile(estimate, alpha)]
+
+    cvar = if !isempty(tail_losses)
+        MeanEstimate(tail_losses)
+    else
+        MeanEstimate(0.)
+    end
+    
+    return CVAR{N,L,T,E}(cvar, alpha)
+
+end
 function finalize(
     acc::ShortfallSamplesAccumulator{S},
     system::SystemModel{N,L,T,P,E},

--- a/PRASCore.jl/src/Results/ShortfallSamples.jl
+++ b/PRASCore.jl/src/Results/ShortfallSamples.jl
@@ -190,7 +190,7 @@ function CVAR(x::ShortfallSamplesResult{N,L,T,P,E}, alpha::Float64) where {N,L,T
     
     estimate = x[]
     var = quantile(estimate, alpha)
-    tail_losses = estimate[estimate .> var]
+    tail_losses = estimate[estimate .>= var]
 
     cvar = if !isempty(tail_losses)
         MeanEstimate(tail_losses)

--- a/PRASCore.jl/src/Results/ShortfallSamples.jl
+++ b/PRASCore.jl/src/Results/ShortfallSamples.jl
@@ -82,6 +82,7 @@ struct ShortfallSamplesResult{N,L,T<:Period,P<:PowerUnit,E<:EnergyUnit, S} <: Ab
     timestamps::StepRange{ZonedDateTime,T}
 
     shortfall::Array{Int,3} # r x t x s
+    capacity_shortfall::Array{Int,2} # r x s
 
 end
 
@@ -197,18 +198,17 @@ function CVAR(x::ShortfallSamplesResult{N,L,T,P,E}, alpha::Float64) where {N,L,T
         MeanEstimate(0.)
     end
 
-    period_estimate = x.shortfall[:]
-    period_var = quantile(period_estimate, alpha)
-    period_tail_losses = period_estimate[period_estimate .>= period_var]
+    capacity_estimate = x.capacity_shortfall[:]
+    capacity_var = quantile(capacity_estimate, alpha)
+    capacity_tail_losses = capacity_estimate[capacity_estimate .>= capacity_var]
 
-    period_cvar = if !isempty(period_tail_losses)
-        MeanEstimate(period_tail_losses)
+    capacity_cvar = if !isempty(capacity_tail_losses)
+        MeanEstimate(capacity_tail_losses)
     else
         MeanEstimate(0.)
     end     
 
-    
-    return CVAR{N,L,T,E}(cvar, alpha, var, period_cvar, period_var)
+    return CVAR{N,L,T,E}(cvar, alpha, var, capacity_cvar, capacity_var)
 
 end
 
@@ -224,17 +224,17 @@ function CVAR(x::ShortfallSamplesResult{N,L,T,P,E}, alpha::Float64, r::AbstractS
     end
     
     i_r = findfirstunique(x.regions.names, r)
-    period_estimate = x.shortfall[i_r, :, :][:]
-    period_var = quantile(period_estimate, alpha)
-    period_tail_losses = period_estimate[period_estimate .>= period_var]
+    capacity_estimate = x.capacity_shortfall[i_r, :]
+    capacity_var = quantile(capacity_estimate, alpha)
+    capacity_tail_losses = capacity_estimate[capacity_estimate .>= capacity_var]
 
-    period_cvar = if !isempty(period_tail_losses)
-        MeanEstimate(period_tail_losses)
+    capacity_cvar = if !isempty(capacity_tail_losses)
+        MeanEstimate(capacity_tail_losses)
     else
         MeanEstimate(0.)
-    end  
+    end     
 
-    return CVAR{N,L,T,E}(cvar, alpha, var, period_cvar, period_var)
+    return CVAR{N,L,T,E}(cvar, alpha, var, capacity_cvar, capacity_var)
 
 end
 
@@ -303,7 +303,10 @@ function finalize(
     system::SystemModel{N,L,T,P,E},
 ) where {N,L,T,P,E,S<:Union{ShortfallSamples,DemandResponseShortfallSamples}}
 
+    n_regions = length(system.regions)
+    p2e = conversionfactor(L,T,P,E)
+    max_capacity_shortfall = reshape(maximum(acc.shortfall, dims=[2]) ./ p2e, n_regions, :)
     return ShortfallSamplesResult{N,L,T,P,E,S}(
-        system.regions, system.timestamps, acc.shortfall)
+        system.regions, system.timestamps, acc.shortfall, max_capacity_shortfall)
 
 end

--- a/PRASCore.jl/src/Results/ShortfallSamples.jl
+++ b/PRASCore.jl/src/Results/ShortfallSamples.jl
@@ -198,17 +198,17 @@ function CVAR(x::ShortfallSamplesResult{N,L,T,P,E}, alpha::Float64) where {N,L,T
         MeanEstimate(0.)
     end
 
-    capacity_estimate = x.capacity_shortfall[:]
-    capacity_var = quantile(capacity_estimate, alpha)
-    capacity_tail_losses = capacity_estimate[capacity_estimate .>= capacity_var]
+    # capacity_estimate = x.capacity_shortfall[:]
+    # capacity_var = quantile(capacity_estimate, alpha)
+    # capacity_tail_losses = capacity_estimate[capacity_estimate .>= capacity_var]
 
-    capacity_cvar = if !isempty(capacity_tail_losses)
-        MeanEstimate(capacity_tail_losses)
-    else
-        MeanEstimate(0.)
-    end     
+    # capacity_cvar = if !isempty(capacity_tail_losses)
+    #     MeanEstimate(capacity_tail_losses)
+    # else
+    #     MeanEstimate(0.)
+    # end     
 
-    return CVAR{N,L,T,E}(cvar, alpha, var, capacity_cvar, capacity_var)
+    return CVAR{N,L,T,E}(cvar, alpha, var)
 
 end
 
@@ -223,18 +223,18 @@ function CVAR(x::ShortfallSamplesResult{N,L,T,P,E}, alpha::Float64, r::AbstractS
         MeanEstimate(0.)
     end
     
-    i_r = findfirstunique(x.regions.names, r)
-    capacity_estimate = x.capacity_shortfall[i_r, :]
-    capacity_var = quantile(capacity_estimate, alpha)
-    capacity_tail_losses = capacity_estimate[capacity_estimate .>= capacity_var]
+    # i_r = findfirstunique(x.regions.names, r)
+    # capacity_estimate = x.capacity_shortfall[i_r, :]
+    # capacity_var = quantile(capacity_estimate, alpha)
+    # capacity_tail_losses = capacity_estimate[capacity_estimate .>= capacity_var]
 
-    capacity_cvar = if !isempty(capacity_tail_losses)
-        MeanEstimate(capacity_tail_losses)
-    else
-        MeanEstimate(0.)
-    end     
+    # capacity_cvar = if !isempty(capacity_tail_losses)
+    #     MeanEstimate(capacity_tail_losses)
+    # else
+    #     MeanEstimate(0.)
+    # end     
 
-    return CVAR{N,L,T,E}(cvar, alpha, var, capacity_cvar, capacity_var)
+    return CVAR{N,L,T,E}(cvar, alpha, var)
 
 end
 

--- a/PRASCore.jl/src/Results/ShortfallSamples.jl
+++ b/PRASCore.jl/src/Results/ShortfallSamples.jl
@@ -237,7 +237,7 @@ function NCVAR(x::ShortfallSamplesResult, cvar::CVAR)
 
     ncvar, var = _ncvar(cvar, demand)
 
-    return NCVAR(cvar.dim, ncvar, cvar.alpha, var)
+    return NCVAR(cvar.quantity, ncvar, cvar.alpha, var)
 
 end
 
@@ -246,7 +246,7 @@ function NCVAR(x::ShortfallSamplesResult, cvar::CVAR, r::AbstractString)
     demand = sum(x.regions.load[i_r, :])
 
     ncvar, var = _ncvar(cvar, demand)
-    return NCVAR(cvar.dim, ncvar, cvar.alpha, var)
+    return NCVAR(cvar.quantity, ncvar, cvar.alpha, var)
 
 end
 

--- a/PRASCore.jl/src/Results/ShortfallSamples.jl
+++ b/PRASCore.jl/src/Results/ShortfallSamples.jl
@@ -229,7 +229,10 @@ function CVAR(::Val{:energy}, x::ShortfallSamplesResult{N,L,T,P,E}, alpha::Float
     return CVAR{N,L,T,E}(:energy, cvar, alpha, var)
 end
 
-function NCVAR(x::ShortfallSamplesResult{N,L,T,P}, cvar::CVAR) where {N,L,T,P}
+CVAR(dim::Symbol, x::ShortfallSamplesResult, alpha::Float64, ::Colon, t::StepRange{ZonedDateTime}) =
+    CVAR.(dim, x, alpha, x.regions.names, Ref(t))
+
+function NCVAR(x::ShortfallSamplesResult, cvar::CVAR)
     demand = sum(x.regions.load)
 
     ncvar, var = _ncvar(cvar, demand)
@@ -238,7 +241,7 @@ function NCVAR(x::ShortfallSamplesResult{N,L,T,P}, cvar::CVAR) where {N,L,T,P}
 
 end
 
-function NCVAR(x::ShortfallSamplesResult{N,L,T,P}, cvar::CVAR, r::AbstractString) where {N,L,T,P}
+function NCVAR(x::ShortfallSamplesResult, cvar::CVAR, r::AbstractString)
     i_r = findfirstunique(x.regions.names, r)
     demand = sum(x.regions.load[i_r, :])
 

--- a/PRASCore.jl/src/Results/ShortfallSamples.jl
+++ b/PRASCore.jl/src/Results/ShortfallSamples.jl
@@ -234,7 +234,7 @@ function NCVAR(x::ShortfallSamplesResult{N,L,T,P}, cvar::CVAR) where {N,L,T,P}
 
     ncvar, var = _ncvar(cvar, demand)
 
-    return NCVAR(ncvar, cvar.alpha, var)
+    return NCVAR(cvar.dim, ncvar, cvar.alpha, var)
 
 end
 
@@ -243,7 +243,7 @@ function NCVAR(x::ShortfallSamplesResult{N,L,T,P}, cvar::CVAR, r::AbstractString
     demand = sum(x.regions.load[i_r, :])
 
     ncvar, var = _ncvar(cvar, demand)
-    return NCVAR(ncvar, cvar.alpha, var)
+    return NCVAR(cvar.dim, ncvar, cvar.alpha, var)
 
 end
 

--- a/PRASCore.jl/src/Results/metrics.jl
+++ b/PRASCore.jl/src/Results/metrics.jl
@@ -225,14 +225,17 @@ respectively.
 """
 struct NCVAR <: ReliabilityMetric
 
+    dim::Symbol
     ncvar::MeanEstimate
     alpha::Float64
     var::Float64
     
-    function NCVAR(ncvar::MeanEstimate, alpha::Float64, var::Float64)
+    function NCVAR(dim::Symbol, ncvar::MeanEstimate, alpha::Float64, var::Float64)
+
+        _check_dim(dim)
         val(ncvar) >= 0 || throw(DomainError(val(ncvar),
             "$(val(ncvar)) is not a valid NCVAR"))
-        new(ncvar, alpha, var)
+        new(dim, ncvar, alpha, var)
     end
 
 end

--- a/PRASCore.jl/src/Results/metrics.jl
+++ b/PRASCore.jl/src/Results/metrics.jl
@@ -172,7 +172,7 @@ end
 """
     CVAR
 
-`CVAR` reports conditional value at risk of shortfalls, for total unserved energy and capacity shortfalls.
+`CVAR` reports conditional value at risk of shortfalls, for total unserved energy shortfalls.
 
 Contains both the estimated value itself as well as the standard error
 of that estimate, which can be extracted with `val` and `stderror`,
@@ -180,7 +180,7 @@ respectively.
 """
 struct CVAR{N,L,T<:Period,E<:EnergyUnit} <: ReliabilityMetric
 
-    unit::Union{Type{<:EnergyUnit}, Type{<:PowerUnit}}
+    unit::Type{<:EnergyUnit}
     cvar::MeanEstimate
     alpha::Float64
     var::Float64
@@ -193,7 +193,7 @@ struct CVAR{N,L,T<:Period,E<:EnergyUnit} <: ReliabilityMetric
                             L,
                             T<:Period,
                             E<:EnergyUnit,
-                            U<:Union{Type{<:EnergyUnit}, Type{<:PowerUnit}}
+                            U<:Type{<:EnergyUnit},
                             }
         val(cvar) >= 0 || throw(DomainError(val(cvar),
             "$(val(cvar)) is not a valid CVAR"))
@@ -215,7 +215,7 @@ end
 """
     NCVAR
 
-`NCVAR` reports normalized conditional value at risk of shortfalls, for total unserved energy and capacity shortfalls.
+`NCVAR` reports normalized conditional value at risk of shortfalls, for total unserved energy shortfalls.
 
 Contains both the estimated value itself as well as the standard error
 of that estimate, which can be extracted with `val` and `stderror`,

--- a/PRASCore.jl/src/Results/metrics.jl
+++ b/PRASCore.jl/src/Results/metrics.jl
@@ -180,20 +180,24 @@ respectively.
 """
 struct CVAR{N,L,T<:Period,E<:EnergyUnit} <: ReliabilityMetric
 
+    unit::Union{Type{<:EnergyUnit}, Type{<:PowerUnit}}
     cvar::MeanEstimate
     alpha::Float64
     var::Float64
-    capacity_cvar::MeanEstimate
-    capacity_var::Float64
     
-    function CVAR{N,L,T,E}(cvar::MeanEstimate,
+    function CVAR{N,L,T,E}(unit::U,
+                           cvar::MeanEstimate,
                            alpha::Float64,
-                           var::Float64,
-                           capacity_cvar::MeanEstimate,
-                           capacity_var::Float64) where {N,L,T<:Period,E<:EnergyUnit}
+                           var::Float64) where {
+                            N,
+                            L,
+                            T<:Period,
+                            E<:EnergyUnit,
+                            U<:Union{Type{<:EnergyUnit}, Type{<:PowerUnit}}
+                            }
         val(cvar) >= 0 || throw(DomainError(val(cvar),
             "$(val(cvar)) is not a valid CVAR"))
-        new{N,L,T,E}(cvar, alpha, var, capacity_cvar, capacity_var)
+        new{N,L,T,E}(unit, cvar, alpha, var)
     end
 
 end
@@ -204,7 +208,7 @@ stderror(x::CVAR) = stderror(x.cvar)
 function Base.show(io::IO, x::CVAR{N,L,T,E}) where {N,L,T,E}
     
     print(io, "CVAR@$(x.alpha) = ", x.cvar, " ",
-          unitsymbol(E), "/", N*L == 1 ? "" : N*L, unitsymbol(T))
+          unitsymbol(x.unit), "/", N*L == 1 ? "" : N*L, unitsymbol(T))
 
 end
 

--- a/PRASCore.jl/src/Results/metrics.jl
+++ b/PRASCore.jl/src/Results/metrics.jl
@@ -172,7 +172,7 @@ end
 """
     CVAR
 
-`CVAR` reports conditional value at risk of shortfalls.
+`CVAR` reports conditional value at risk of shortfalls, for total unserved energy and capacity shortfalls.
 
 Contains both the estimated value itself as well as the standard error
 of that estimate, which can be extracted with `val` and `stderror`,
@@ -183,17 +183,17 @@ struct CVAR{N,L,T<:Period,E<:EnergyUnit} <: ReliabilityMetric
     cvar::MeanEstimate
     alpha::Float64
     var::Float64
-    period_cvar::MeanEstimate
-    period_var::Float64
+    capacity_cvar::MeanEstimate
+    capacity_var::Float64
     
     function CVAR{N,L,T,E}(cvar::MeanEstimate,
                            alpha::Float64,
                            var::Float64,
-                           period_cvar::MeanEstimate,
-                           period_var::Float64) where {N,L,T<:Period,E<:EnergyUnit}
+                           capacity_cvar::MeanEstimate,
+                           capacity_var::Float64) where {N,L,T<:Period,E<:EnergyUnit}
         val(cvar) >= 0 || throw(DomainError(
             "$val is not a valid CVAR"))
-        new{N,L,T,E}(cvar, alpha, var, period_cvar, period_var)
+        new{N,L,T,E}(cvar, alpha, var, capacity_cvar, capacity_var)
     end
 
 end
@@ -211,7 +211,7 @@ end
 """
     NCVAR
 
-`NCVAR` reports normalized conditional value at risk of shortfalls.
+`NCVAR` reports normalized conditional value at risk of shortfalls, for total unserved energy and capacity shortfalls.
 
 Contains both the estimated value itself as well as the standard error
 of that estimate, which can be extracted with `val` and `stderror`,

--- a/PRASCore.jl/src/Results/metrics.jl
+++ b/PRASCore.jl/src/Results/metrics.jl
@@ -206,15 +206,15 @@ Contains both the estimated value itself as well as the standard error
 of that estimate, which can be extracted with `val` and `stderror`,
 respectively.
 """
-struct NCVAR{N,L,T<:Period} <: ReliabilityMetric
+struct NCVAR <: ReliabilityMetric
 
     ncvar::MeanEstimate
     alpha::Float64
     
-    function NCVAR{N,L,T}(ncvar::MeanEstimate, alpha::Float64) where {N,L,T<:Period}
+    function NCVAR(ncvar::MeanEstimate, alpha::Float64)
         val(ncvar) >= 0 || throw(DomainError(
             "$val is not a valid NCVAR"))
-        new{N,L,T}(ncvar, alpha)
+        new(ncvar, alpha)
     end
 
 end

--- a/PRASCore.jl/src/Results/metrics.jl
+++ b/PRASCore.jl/src/Results/metrics.jl
@@ -169,7 +169,7 @@ function Base.show(io::IO, x::NEUE)
 
 end
 
-const CVAR_METRICS = (:energy,)
+const CVAR_QUANTITIES = (:energy,)
 
 
 """
@@ -183,21 +183,20 @@ respectively.
 """
 struct CVAR{N,L,T<:Period,E<:EnergyUnit} <: ReliabilityMetric
 
-    dim::Symbol
+    quantity::Symbol
     cvar::MeanEstimate
     alpha::Float64
     var::Float64
 
-    function CVAR{N,L,T,E}(dim::Symbol,
+    function CVAR{N,L,T,E}(quantity::Symbol,
                            cvar::MeanEstimate,
                            alpha::Float64,
                            var::Float64) where {N,L,T<:Period,E<:EnergyUnit}
-        # _check_dim(dim)
         val(cvar) >= 0 || throw(DomainError(val(cvar),
             "$(val(cvar)) is not a valid CVAR"))
         0 <= alpha < 1 || throw(DomainError(alpha,
             "$alpha is not a valid confidence level"))
-        new{N,L,T,E}(dim, cvar, alpha, var)
+        new{N,L,T,E}(quantity, cvar, alpha, var)
     end
 
 end
@@ -221,17 +220,16 @@ respectively.
 """
 struct NCVAR <: ReliabilityMetric
 
-    dim::Symbol
+    quantity::Symbol
     ncvar::MeanEstimate
     alpha::Float64
     var::Float64
     
-    function NCVAR(dim::Symbol, ncvar::MeanEstimate, alpha::Float64, var::Float64)
+    function NCVAR(quantity::Symbol, ncvar::MeanEstimate, alpha::Float64, var::Float64)
 
-        _check_dim(dim)
         val(ncvar) >= 0 || throw(DomainError(val(ncvar),
             "$(val(ncvar)) is not a valid NCVAR"))
-        new(dim, ncvar, alpha, var)
+        new(quantity, ncvar, alpha, var)
     end
 
 end

--- a/PRASCore.jl/src/Results/metrics.jl
+++ b/PRASCore.jl/src/Results/metrics.jl
@@ -196,3 +196,33 @@ function Base.show(io::IO, x::CVAR{N,L,T,E}) where {N,L,T,E}
           unitsymbol(E), "/", N*L == 1 ? "" : N*L, unitsymbol(T))
 
 end
+
+"""
+    NCVAR
+
+`NCVAR` reports normalized conditional value at risk of shortfalls.
+
+Contains both the estimated value itself as well as the standard error
+of that estimate, which can be extracted with `val` and `stderror`,
+respectively.
+"""
+struct NCVAR{N,L,T<:Period} <: ReliabilityMetric
+
+    ncvar::MeanEstimate
+    alpha::Float64
+    
+    function NCVAR{N,L,T}(ncvar::MeanEstimate, alpha::Float64) where {N,L,T<:Period}
+        val(ncvar) >= 0 || throw(DomainError(
+            "$val is not a valid NCVAR"))
+        new{N,L,T}(ncvar, alpha)
+    end
+
+end
+
+val(x::NCVAR) = val(x.ncvar)
+stderror(x::NCVAR) = stderror(x.ncvar)
+
+function Base.show(io::IO, x::NCVAR)
+    print(io, "NCVAR@$(x.alpha) = ", x.ncvar, " ppm")
+
+end

--- a/PRASCore.jl/src/Results/metrics.jl
+++ b/PRASCore.jl/src/Results/metrics.jl
@@ -191,8 +191,8 @@ struct CVAR{N,L,T<:Period,E<:EnergyUnit} <: ReliabilityMetric
                            var::Float64,
                            capacity_cvar::MeanEstimate,
                            capacity_var::Float64) where {N,L,T<:Period,E<:EnergyUnit}
-        val(cvar) >= 0 || throw(DomainError(
-            "$val is not a valid CVAR"))
+        val(cvar) >= 0 || throw(DomainError(val(cvar),
+            "$(val(cvar)) is not a valid CVAR"))
         new{N,L,T,E}(cvar, alpha, var, capacity_cvar, capacity_var)
     end
 
@@ -224,8 +224,8 @@ struct NCVAR <: ReliabilityMetric
     var::Float64
     
     function NCVAR(ncvar::MeanEstimate, alpha::Float64, var::Float64)
-        val(ncvar) >= 0 || throw(DomainError(
-            "$val is not a valid NCVAR"))
+        val(ncvar) >= 0 || throw(DomainError(val(ncvar),
+            "$(val(ncvar)) is not a valid NCVAR"))
         new(ncvar, alpha, var)
     end
 

--- a/PRASCore.jl/src/Results/metrics.jl
+++ b/PRASCore.jl/src/Results/metrics.jl
@@ -178,11 +178,13 @@ struct CVAR{N,L,T<:Period,E<:EnergyUnit} <: ReliabilityMetric
 
     cvar::MeanEstimate
     alpha::Float64
+    var::Float64
+    cvar_type::String
     
-    function CVAR{N,L,T,E}(cvar::MeanEstimate, alpha::Float64) where {N,L,T<:Period,E<:EnergyUnit}
+    function CVAR{N,L,T,E}(cvar::MeanEstimate, alpha::Float64, var::Float64, cvar_type::String) where {N,L,T<:Period,E<:EnergyUnit}
         val(cvar) >= 0 || throw(DomainError(
             "$val is not a valid CVAR"))
-        new{N,L,T,E}(cvar, alpha)
+        new{N,L,T,E}(cvar, alpha, var, cvar_type)
     end
 
 end
@@ -191,9 +193,15 @@ val(x::CVAR) = val(x.cvar)
 stderror(x::CVAR) = stderror(x.cvar)
 
 function Base.show(io::IO, x::CVAR{N,L,T,E}) where {N,L,T,E}
-
-    print(io, "CVAR@$(x.alpha) = ", x.cvar, " ",
+    if x.cvar_type == "period"
+        print(io, "CVAR@$(x.alpha) = ", x.cvar, " ",
+          unitsymbol(E))
+    else
+        print(io, "CVAR@$(x.alpha) = ", x.cvar, " ",
           unitsymbol(E), "/", N*L == 1 ? "" : N*L, unitsymbol(T))
+    end
+    # print(io, "CVAR@$(x.alpha) = ", x.cvar, " ",
+    #       unitsymbol(E), "/", N*L == 1 ? "" : N*L, unitsymbol(T))
 
 end
 
@@ -210,11 +218,12 @@ struct NCVAR <: ReliabilityMetric
 
     ncvar::MeanEstimate
     alpha::Float64
+    var::Float64
     
-    function NCVAR(ncvar::MeanEstimate, alpha::Float64)
+    function NCVAR(ncvar::MeanEstimate, alpha::Float64, var::Float64)
         val(ncvar) >= 0 || throw(DomainError(
             "$val is not a valid NCVAR"))
-        new(ncvar, alpha)
+        new(ncvar, alpha, var)
     end
 
 end

--- a/PRASCore.jl/src/Results/metrics.jl
+++ b/PRASCore.jl/src/Results/metrics.jl
@@ -25,6 +25,7 @@ function MeanEstimate(xs::AbstractArray{<:Real})
     if length(xs) > 1
         MeanEstimate(est, std(xs, mean=est), length(xs))
     else
+        @warn "Only one sample provided; standard error will be zero"
         MeanEstimate(est)
     end
 end
@@ -171,6 +172,7 @@ end
 
 const CVAR_QUANTITIES = (:energy,)
 
+_cvar_quantity_unitsymbol(::Val{:energy}, ::Type{E}, ::Type) where {E<:EnergyUnit} = unitsymbol(E)
 
 """
     CVAR
@@ -206,7 +208,7 @@ stderror(x::CVAR) = stderror(x.cvar)
 
 function Base.show(io::IO, x::CVAR{N,L,T,E}) where {N,L,T,E}
     print(io, "CVAR@$(x.alpha) = ", x.cvar, " ",
-          unitsymbol(E), "/", N*L == 1 ? "" : N*L, unitsymbol(T))
+          _cvar_quantity_unitsymbol(Val(x.quantity), E, T), "/", N*L == 1 ? "" : N*L, unitsymbol(T))
 end
 
 """

--- a/PRASCore.jl/src/Results/metrics.jl
+++ b/PRASCore.jl/src/Results/metrics.jl
@@ -197,6 +197,9 @@ struct CVAR{N,L,T<:Period,E<:EnergyUnit} <: ReliabilityMetric
                             }
         val(cvar) >= 0 || throw(DomainError(val(cvar),
             "$(val(cvar)) is not a valid CVAR"))
+        0 <= alpha < 1 || throw(DomainError(alpha,
+         "$alpha is not a valid confidence level"))
+
         new{N,L,T,E}(unit, cvar, alpha, var)
     end
 

--- a/PRASCore.jl/src/Results/metrics.jl
+++ b/PRASCore.jl/src/Results/metrics.jl
@@ -164,3 +164,35 @@ function Base.show(io::IO, x::NEUE)
     print(io, "NEUE = ", x.neue, " ppm")
 
 end
+
+"""
+    CVAR
+
+`CVAR` reports conditional value at risk of shortfalls.
+
+Contains both the estimated value itself as well as the standard error
+of that estimate, which can be extracted with `val` and `stderror`,
+respectively.
+"""
+struct CVAR{N,L,T<:Period,E<:EnergyUnit} <: ReliabilityMetric
+
+    cvar::MeanEstimate
+    alpha::Float64
+    
+    function CVAR{N,L,T,E}(cvar::MeanEstimate, alpha::Float64) where {N,L,T<:Period,E<:EnergyUnit}
+        val(cvar) >= 0 || throw(DomainError(
+            "$val is not a valid CVAR"))
+        new{N,L,T,E}(cvar, alpha)
+    end
+
+end
+
+val(x::CVAR) = val(x.cvar)
+stderror(x::CVAR) = stderror(x.cvar)
+
+function Base.show(io::IO, x::CVAR{N,L,T,E}) where {N,L,T,E}
+
+    print(io, "CVAR@$(x.alpha) = ", x.cvar, " ",
+          unitsymbol(E), "/", N*L == 1 ? "" : N*L, unitsymbol(T))
+
+end

--- a/PRASCore.jl/src/Results/metrics.jl
+++ b/PRASCore.jl/src/Results/metrics.jl
@@ -169,6 +169,13 @@ function Base.show(io::IO, x::NEUE)
 
 end
 
+const CVAR_METRICS = (:energy,)
+
+function _check_dim(dim::Symbol, valid::Tuple{Vararg{Symbol}}=CVAR_METRICS)
+    dim in valid ||
+        throw(ArgumentError("$dim is not a valid dim, use one of $valid"))
+end
+
 """
     CVAR
 
@@ -180,27 +187,21 @@ respectively.
 """
 struct CVAR{N,L,T<:Period,E<:EnergyUnit} <: ReliabilityMetric
 
-    unit::Type{<:EnergyUnit}
+    dim::Symbol
     cvar::MeanEstimate
     alpha::Float64
     var::Float64
-    
-    function CVAR{N,L,T,E}(unit::U,
+
+    function CVAR{N,L,T,E}(dim::Symbol,
                            cvar::MeanEstimate,
                            alpha::Float64,
-                           var::Float64) where {
-                            N,
-                            L,
-                            T<:Period,
-                            E<:EnergyUnit,
-                            U<:Type{<:EnergyUnit},
-                            }
+                           var::Float64) where {N,L,T<:Period,E<:EnergyUnit}
+        _check_dim(dim)
         val(cvar) >= 0 || throw(DomainError(val(cvar),
             "$(val(cvar)) is not a valid CVAR"))
         0 <= alpha < 1 || throw(DomainError(alpha,
-         "$alpha is not a valid confidence level"))
-
-        new{N,L,T,E}(unit, cvar, alpha, var)
+            "$alpha is not a valid confidence level"))
+        new{N,L,T,E}(dim, cvar, alpha, var)
     end
 
 end
@@ -209,10 +210,8 @@ val(x::CVAR) = val(x.cvar)
 stderror(x::CVAR) = stderror(x.cvar)
 
 function Base.show(io::IO, x::CVAR{N,L,T,E}) where {N,L,T,E}
-    
     print(io, "CVAR@$(x.alpha) = ", x.cvar, " ",
-          unitsymbol(x.unit), "/", N*L == 1 ? "" : N*L, unitsymbol(T))
-
+          unitsymbol(E), "/", N*L == 1 ? "" : N*L, unitsymbol(T))
 end
 
 """

--- a/PRASCore.jl/src/Results/metrics.jl
+++ b/PRASCore.jl/src/Results/metrics.jl
@@ -22,7 +22,11 @@ MeanEstimate(mu::Real, sigma::Real, n::Int) = MeanEstimate(mu, sigma / sqrt(n))
 
 function MeanEstimate(xs::AbstractArray{<:Real})
     est = mean(xs)
-    return MeanEstimate(est, std(xs, mean=est), length(xs))
+    if length(xs) > 1
+        MeanEstimate(est, std(xs, mean=est), length(xs))
+    else
+        MeanEstimate(est)
+    end
 end
 
 val(est::MeanEstimate) = est.estimate
@@ -179,12 +183,17 @@ struct CVAR{N,L,T<:Period,E<:EnergyUnit} <: ReliabilityMetric
     cvar::MeanEstimate
     alpha::Float64
     var::Float64
-    cvar_type::String
+    period_cvar::MeanEstimate
+    period_var::Float64
     
-    function CVAR{N,L,T,E}(cvar::MeanEstimate, alpha::Float64, var::Float64, cvar_type::String) where {N,L,T<:Period,E<:EnergyUnit}
+    function CVAR{N,L,T,E}(cvar::MeanEstimate,
+                           alpha::Float64,
+                           var::Float64,
+                           period_cvar::MeanEstimate,
+                           period_var::Float64) where {N,L,T<:Period,E<:EnergyUnit}
         val(cvar) >= 0 || throw(DomainError(
             "$val is not a valid CVAR"))
-        new{N,L,T,E}(cvar, alpha, var, cvar_type)
+        new{N,L,T,E}(cvar, alpha, var, period_cvar, period_var)
     end
 
 end
@@ -193,15 +202,9 @@ val(x::CVAR) = val(x.cvar)
 stderror(x::CVAR) = stderror(x.cvar)
 
 function Base.show(io::IO, x::CVAR{N,L,T,E}) where {N,L,T,E}
-    if x.cvar_type == "period"
-        print(io, "CVAR@$(x.alpha) = ", x.cvar, " ",
-          unitsymbol(E))
-    else
-        print(io, "CVAR@$(x.alpha) = ", x.cvar, " ",
+    
+    print(io, "CVAR@$(x.alpha) = ", x.cvar, " ",
           unitsymbol(E), "/", N*L == 1 ? "" : N*L, unitsymbol(T))
-    end
-    # print(io, "CVAR@$(x.alpha) = ", x.cvar, " ",
-    #       unitsymbol(E), "/", N*L == 1 ? "" : N*L, unitsymbol(T))
 
 end
 

--- a/PRASCore.jl/src/Results/metrics.jl
+++ b/PRASCore.jl/src/Results/metrics.jl
@@ -171,10 +171,6 @@ end
 
 const CVAR_METRICS = (:energy,)
 
-function _check_dim(dim::Symbol, valid::Tuple{Vararg{Symbol}}=CVAR_METRICS)
-    dim in valid ||
-        throw(ArgumentError("$dim is not a valid dim, use one of $valid"))
-end
 
 """
     CVAR
@@ -196,7 +192,7 @@ struct CVAR{N,L,T<:Period,E<:EnergyUnit} <: ReliabilityMetric
                            cvar::MeanEstimate,
                            alpha::Float64,
                            var::Float64) where {N,L,T<:Period,E<:EnergyUnit}
-        _check_dim(dim)
+        # _check_dim(dim)
         val(cvar) >= 0 || throw(DomainError(val(cvar),
             "$(val(cvar)) is not a valid CVAR"))
         0 <= alpha < 1 || throw(DomainError(alpha,

--- a/PRASCore.jl/src/Results/utils.jl
+++ b/PRASCore.jl/src/Results/utils.jl
@@ -47,3 +47,21 @@ function findlastunique(a::AbstractVector{T}, i::T) where T
     return i_idx
 end
 
+function _cvar(estimate::AbstractVector{<:Real}, alpha::Float64)
+    var = quantile(estimate, alpha)
+    tail = estimate[estimate .> var]   
+    cvar = isempty(tail) ? MeanEstimate(0.) : MeanEstimate(tail)
+    return cvar, var
+end
+
+function _ncvar(cvar::CVAR, demand::Real)
+    if demand > 0
+        scale = demand / 1e6
+        ncvar = div(cvar.cvar, scale)
+        var = cvar.var / scale
+    else
+        ncvar = MeanEstimate(0.)
+        var = 0.0
+    end
+    return ncvar, var
+end

--- a/PRASCore.jl/src/Results/utils.jl
+++ b/PRASCore.jl/src/Results/utils.jl
@@ -46,3 +46,4 @@ function findlastunique(a::AbstractVector{T}, i::T) where T
     i_idx === nothing && throw(BoundsError(a))
     return i_idx
 end
+

--- a/PRASCore.jl/src/Results/utils.jl
+++ b/PRASCore.jl/src/Results/utils.jl
@@ -40,3 +40,9 @@ function findfirstunique(a::AbstractVector{T}, i::T) where T
     i_idx === nothing && throw(BoundsError(a))
     return i_idx
 end
+
+function findlastunique(a::AbstractVector{T}, i::T) where T
+    i_idx = findlast(isequal(i), a)
+    i_idx === nothing && throw(BoundsError(a))
+    return i_idx
+end

--- a/PRASCore.jl/src/Simulations/recording.jl
+++ b/PRASCore.jl/src/Simulations/recording.jl
@@ -55,7 +55,9 @@ function record!(
 end
 
 function reset!(acc::Results.ShortfallAccumulator, sampleid::Int)
-
+    # Store total UE for each sample
+    acc.unservedload_sample[sampleid] = acc.unservedload_total_currentsim 
+    
     # Store regional / total sums for current simulation
     fit!(acc.periodsdropped_total, acc.periodsdropped_total_currentsim)
     fit!(acc.unservedload_total, acc.unservedload_total_currentsim)
@@ -63,6 +65,7 @@ function reset!(acc::Results.ShortfallAccumulator, sampleid::Int)
     for r in eachindex(acc.periodsdropped_region)
         fit!(acc.periodsdropped_region[r], acc.periodsdropped_region_currentsim[r])
         fit!(acc.unservedload_region[r], acc.unservedload_region_currentsim[r])
+        acc.unservedload_region_sample[r, sampleid] = acc.unservedload_region_currentsim[r]
     end
 
     # Reset for new simulation

--- a/PRASCore.jl/src/Systems/TestData.jl
+++ b/PRASCore.jl/src/Systems/TestData.jl
@@ -36,7 +36,7 @@ singlenode_a_lole = 0.355
 singlenode_a_lolps = [0.028, 0.271, 0.028, 0.028]
 singlenode_a_eue = 1.59
 singlenode_a_eues = [0.29, 0.832, 0.29, 0.178]
-singlenode_a_cvar = 11.84
+singlenode_a_cvar = 13.34
 
 ## Single-Region System A - 5 minute version
 
@@ -100,7 +100,7 @@ singlenode_b_lole = 0.96
 singlenode_b_lolps = [0.19, 0.19, 0.19, 0.1, 0.1, 0.19]
 singlenode_b_eue = 7.11
 singlenode_b_eues = [1.29, 1.29, 1.29, 0.85, 1.05, 1.34]
-singlenode_b_cvar = 30.44
+singlenode_b_cvar = 31.71
 
 
 # Single-Region System B, with storage

--- a/PRASCore.jl/src/Systems/TestData.jl
+++ b/PRASCore.jl/src/Systems/TestData.jl
@@ -36,6 +36,7 @@ singlenode_a_lole = 0.355
 singlenode_a_lolps = [0.028, 0.271, 0.028, 0.028]
 singlenode_a_eue = 1.59
 singlenode_a_eues = [0.29, 0.832, 0.29, 0.178]
+singlenode_a_cvar = 11.84
 
 ## Single-Region System A - 5 minute version
 
@@ -99,6 +100,7 @@ singlenode_b_lole = 0.96
 singlenode_b_lolps = [0.19, 0.19, 0.19, 0.1, 0.1, 0.19]
 singlenode_b_eue = 7.11
 singlenode_b_eues = [1.29, 1.29, 1.29, 0.85, 1.05, 1.34]
+singlenode_b_cvar = 30.44
 
 
 # Single-Region System B, with storage

--- a/PRASCore.jl/test/Results/metrics.jl
+++ b/PRASCore.jl/test/Results/metrics.jl
@@ -86,13 +86,13 @@
 
     @testset "NCVAR" begin
 
-        ncvar1 = NCVAR(MeanEstimate(1.2), 0.95, 1.2)
+        ncvar1 = NCVAR(:energy, MeanEstimate(1.2), 0.95, 1.2)
         @test string(ncvar1) == "NCVAR@0.95 = 1.20000 ppm"
 
-        ncvar2 = NCVAR(MeanEstimate(17.2, 1.3), 0.95, 1.3)
+        ncvar2 = NCVAR(:energy, MeanEstimate(17.2, 1.3), 0.95, 1.3)
         @test string(ncvar2) == "NCVAR@0.95 = 17±1 ppm"
 
-        @test_throws DomainError NCVAR(MeanEstimate(-1.2), 0.95, -1.2)
+        @test_throws DomainError NCVAR(:energy, MeanEstimate(-1.2), 0.95, -1.2)
 
     end
 

--- a/PRASCore.jl/test/Results/metrics.jl
+++ b/PRASCore.jl/test/Results/metrics.jl
@@ -71,16 +71,16 @@
         @test_throws DomainError NEUE(MeanEstimate(-1.2))
 
     end
-
+  
     @testset "CVAR" begin
 
-        cvar1 = CVAR{2,1,Hour,MWh}(MeanEstimate(1.2), 0.95, 1.2, MeanEstimate(1.0), 1.2)
+        cvar1 = CVAR{2,1,Hour,MWh}(MWh,MeanEstimate(1.2), 0.95, 2.0)
         @test string(cvar1) == "CVAR@0.95 = 1.20000 MWh/2h"
 
-        cvar2 = CVAR{1,2,Year,GWh}(MeanEstimate(17.2, 1.3), 0.95, 1.2, MeanEstimate(17.2, 1.3), 1.2)
+        cvar2 = CVAR{1,2,Year,GWh}(GWh,MeanEstimate(17.2, 1.3), 0.95, 1.2)
         @test string(cvar2) == "CVAR@0.95 = 17±1 GWh/2y"
 
-        @test_throws DomainError CVAR{1,1,Hour,MWh}(MeanEstimate(-1.2), 0.95, 1.2, MeanEstimate(-1.2), 1.2)
+        @test_throws DomainError CVAR{1,1,Hour,MWh}(MWh,MeanEstimate(-1.2), 0.95, 1.2)
 
     end    
 

--- a/PRASCore.jl/test/Results/metrics.jl
+++ b/PRASCore.jl/test/Results/metrics.jl
@@ -74,13 +74,13 @@
   
     @testset "CVAR" begin
 
-        cvar1 = CVAR{2,1,Hour,MWh}(MWh,MeanEstimate(1.2), 0.95, 2.0)
+        cvar1 = CVAR{2,1,Hour,MWh}(:energy,MeanEstimate(1.2), 0.95, 2.0)
         @test string(cvar1) == "CVAR@0.95 = 1.20000 MWh/2h"
 
-        cvar2 = CVAR{1,2,Year,GWh}(GWh,MeanEstimate(17.2, 1.3), 0.95, 1.2)
+        cvar2 = CVAR{1,2,Year,GWh}(:energy,MeanEstimate(17.2, 1.3), 0.95, 1.2)
         @test string(cvar2) == "CVAR@0.95 = 17±1 GWh/2y"
 
-        @test_throws DomainError CVAR{1,1,Hour,MWh}(MWh,MeanEstimate(-1.2), 0.95, 1.2)
+        @test_throws DomainError CVAR{1,1,Hour,MWh}(:energy,MeanEstimate(-1.2), 0.95, 1.2)
 
     end    
 

--- a/PRASCore.jl/test/Results/metrics.jl
+++ b/PRASCore.jl/test/Results/metrics.jl
@@ -72,4 +72,28 @@
 
     end
 
+    @testset "CVAR" begin
+
+        cvar1 = CVAR{2,1,Hour,MWh}(MeanEstimate(1.2), 0.95)
+        @test string(cvar1) == "CVAR@0.95 = 1.20000 MWh/2h"
+
+        cvar2 = CVAR{1,2,Year,GWh}(MeanEstimate(17.2, 1.3), 0.95)
+        @test string(cvar2) == "CVAR@0.95 = 17±1 GWh/2y"
+
+        @test_throws DomainError CVAR{1,1,Hour,MWh}(MeanEstimate(-1.2), 0.95)
+
+    end    
+
+    @testset "NCVAR" begin
+
+        ncvar1 = NCVAR(MeanEstimate(1.2), 0.95)
+        @test string(ncvar1) == "NCVAR@0.95 = 1.20000 ppm"
+
+        ncvar2 = NCVAR(MeanEstimate(17.2, 1.3), 0.95)
+        @test string(ncvar2) == "NCVAR@0.95 = 17±1 ppm"
+
+        @test_throws DomainError NCVAR(MeanEstimate(-1.2), 0.95)
+
+    end
+
 end

--- a/PRASCore.jl/test/Results/metrics.jl
+++ b/PRASCore.jl/test/Results/metrics.jl
@@ -74,25 +74,25 @@
 
     @testset "CVAR" begin
 
-        cvar1 = CVAR{2,1,Hour,MWh}(MeanEstimate(1.2), 0.95)
+        cvar1 = CVAR{2,1,Hour,MWh}(MeanEstimate(1.2), 0.95, 1.2, MeanEstimate(1.0), 1.2)
         @test string(cvar1) == "CVAR@0.95 = 1.20000 MWh/2h"
 
-        cvar2 = CVAR{1,2,Year,GWh}(MeanEstimate(17.2, 1.3), 0.95)
+        cvar2 = CVAR{1,2,Year,GWh}(MeanEstimate(17.2, 1.3), 0.95, 1.2, MeanEstimate(17.2, 1.3), 1.2)
         @test string(cvar2) == "CVAR@0.95 = 17±1 GWh/2y"
 
-        @test_throws DomainError CVAR{1,1,Hour,MWh}(MeanEstimate(-1.2), 0.95)
+        @test_throws DomainError CVAR{1,1,Hour,MWh}(MeanEstimate(-1.2), 0.95, 1.2, MeanEstimate(-1.2), 1.2)
 
     end    
 
     @testset "NCVAR" begin
 
-        ncvar1 = NCVAR(MeanEstimate(1.2), 0.95)
+        ncvar1 = NCVAR(MeanEstimate(1.2), 0.95, 1.2)
         @test string(ncvar1) == "NCVAR@0.95 = 1.20000 ppm"
 
-        ncvar2 = NCVAR(MeanEstimate(17.2, 1.3), 0.95)
+        ncvar2 = NCVAR(MeanEstimate(17.2, 1.3), 0.95, 1.3)
         @test string(ncvar2) == "NCVAR@0.95 = 17±1 ppm"
 
-        @test_throws DomainError NCVAR(MeanEstimate(-1.2), 0.95)
+        @test_throws DomainError NCVAR(MeanEstimate(-1.2), 0.95, -1.2)
 
     end
 

--- a/PRASCore.jl/test/Results/shortfall.jl
+++ b/PRASCore.jl/test/Results/shortfall.jl
@@ -10,7 +10,7 @@
         DD.nsamples, Regions{N,MW}(DD.resourcenames, DD.resource_vals), DD.periods,
         DD.d1, DD.d2, DD.d1_resource, DD.d2_resource,
         DD.d1_period, DD.d2_period, DD.d1_resourceperiod, DD.d2_resourceperiod,
-        DD.d3_resourceperiod,
+        DD.d3_resourceperiod, DD.d3_resourceperiod, 
         DD.d4, DD.d4_resource, DD.d4_period, DD.d4_resourceperiod,
         DD.d1_sample, DD.d1_resourcesample)
 
@@ -36,6 +36,14 @@
     tail_losses = estimate[estimate .>= quantile(estimate, alpha)];
     @test val(cvar) ≈ mean(tail_losses)
     @test stderror(cvar) ≈ std(tail_losses) / sqrt(length(tail_losses))
+
+    capacity_cvar = cvar.capacity_cvar
+    cap_shortfal = vec(reshape(result.capacity_shortfall_mean, 1, :))
+    var = quantile(cap_shortfal, alpha)
+    tail_losses = cap_shortfal[cap_shortfal .>= var]
+    capacity_cvar_check = mean(tail_losses)
+    @test val(capacity_cvar) ≈ capacity_cvar_check
+    @test stderror(capacity_cvar) ≈ std(tail_losses) / sqrt(length(tail_losses))
 
     ncvar = NCVAR(result, cvar)
     @test val(ncvar) ≈ val(cvar) / load*1e6
@@ -63,6 +71,14 @@
     region_tail_losses = region_estimate[region_estimate .>= quantile(region_estimate, alpha)];
     @test val(region_cvar) ≈ mean(region_tail_losses)
     @test stderror(region_cvar) ≈ std(region_tail_losses) / sqrt(length(region_tail_losses))
+
+    region_capacity_cvar = region_cvar.capacity_cvar
+    region_cap_shortfal = result.capacity_shortfall_mean[r_idx, :]
+    var = quantile(region_cap_shortfal, alpha)
+    tail_losses = region_cap_shortfal[region_cap_shortfal .>= var]
+    region_capacity_cvar_check = mean(tail_losses)
+    @test val(region_capacity_cvar) ≈ region_capacity_cvar_check
+    @test stderror(region_capacity_cvar) ≈ std(tail_losses) / sqrt(length(tail_losses))
 
     region_ncvar = NCVAR(result, region_cvar, r)
     @test val(region_ncvar) ≈ val(region_cvar) / load*1e6
@@ -128,7 +144,7 @@ end
     alpha = 0.95
 
     result = PRASCore.Results.ShortfallSamplesResult{N,1,Hour,MW,MWh,ShortfallSamples}(
-        Regions{N,MW}(DD.resourcenames, DD.resource_vals), DD.periods, DD.d)
+        Regions{N,MW}(DD.resourcenames, DD.resource_vals), DD.periods, DD.d, DD.cap_d)
 
     # Overall
 
@@ -154,6 +170,14 @@ end
     tail_losses = estimate[estimate .>= quantile(estimate, alpha)];
     @test val(cvar) ≈ mean(tail_losses)
     @test stderror(cvar) ≈ std(tail_losses) / sqrt(length(tail_losses))
+
+    capacity_cvar = cvar.capacity_cvar
+    cap_shortfal = vec(reshape(result.capacity_shortfall, 1, :))
+    var = quantile(cap_shortfal, alpha)
+    tail_losses = cap_shortfal[cap_shortfal .>= var]
+    capacity_cvar_check = mean(tail_losses)
+    @test val(capacity_cvar) ≈ capacity_cvar_check
+    @test stderror(capacity_cvar) ≈ std(tail_losses) / sqrt(length(tail_losses))
 
     ncvar = NCVAR(result, cvar)
     @test val(ncvar) ≈ val(cvar) / load*1e6
@@ -183,6 +207,14 @@ end
     region_tail_losses = region_estimate[region_estimate .>= quantile(region_estimate, alpha)];
     @test val(region_cvar) ≈ mean(region_tail_losses)
     @test stderror(region_cvar) ≈ std(region_tail_losses) / sqrt(length(region_tail_losses))
+
+    region_capacity_cvar = region_cvar.capacity_cvar
+    region_cap_shortfal = result.capacity_shortfall[r_idx, :]
+    var = quantile(region_cap_shortfal, alpha)
+    tail_losses = region_cap_shortfal[region_cap_shortfal .>= var]
+    region_capacity_cvar_check = mean(tail_losses)
+    @test val(region_capacity_cvar) ≈ region_capacity_cvar_check
+    @test stderror(region_capacity_cvar) ≈ std(tail_losses) / sqrt(length(tail_losses))
 
     region_ncvar = NCVAR(result, region_cvar, r)
     @test val(region_ncvar) ≈ val(region_cvar) / load*1e6

--- a/PRASCore.jl/test/Results/shortfall.jl
+++ b/PRASCore.jl/test/Results/shortfall.jl
@@ -8,11 +8,11 @@
     energyunit = MWh
 
     result = PRASCore.Results.ShortfallResult{N,1,Hour,MWh,Shortfall}(
-        DD.nsamples, Regions{N,MW}(DD.resourcenames, DD.resource_vals), DD.periods,
-        DD.d1, DD.d2, DD.d1_resource, DD.d2_resource,
-        DD.d1_period, DD.d2_period, DD.d1_resourceperiod, DD.d2_resourceperiod,
-        DD.d3_resourceperiod, DD.d3_resourceperiod, 
-        DD.d4, DD.d4_resource, DD.d4_period, DD.d4_resourceperiod,
+        DD.nsamples, Regions{N,MW}(DD.resourcenames, DD.resource_vals),
+        DD.periods, DD.d1, DD.d2, DD.d1_resource, DD.d2_resource,
+        DD.d1_period, DD.d2_period, DD.d1_resourceperiod,
+        DD.d2_resourceperiod, DD.d3_resourceperiod, DD.d4,
+        DD.d4_resource, DD.d4_period, DD.d4_resourceperiod,
         DD.d1_sample, DD.d1_resourcesample)
 
     # Overall
@@ -130,7 +130,7 @@ end
     energyunit = MWh
 
     result = PRASCore.Results.ShortfallSamplesResult{N,1,Hour,MW,MWh,ShortfallSamples}(
-        Regions{N,MW}(DD.resourcenames, DD.resource_vals), DD.periods, DD.d, DD.cap_d)
+        Regions{N,MW}(DD.resourcenames, DD.resource_vals), DD.periods, DD.d)
 
     # Overall
 

--- a/PRASCore.jl/test/Results/shortfall.jl
+++ b/PRASCore.jl/test/Results/shortfall.jl
@@ -5,7 +5,6 @@
     r, r_idx, r_bad = DD.testresource, DD.testresource_idx, DD.notaresource
     t, t_idx, t_bad = DD.testperiod, DD.testperiod_idx, DD.notaperiod
     alpha = DD.alpha
-    energyunit = MWh
 
     result = PRASCore.Results.ShortfallResult{N,1,Hour,MWh,Shortfall}(
         DD.nsamples, Regions{N,MW}(DD.resourcenames, DD.resource_vals),
@@ -32,9 +31,9 @@
     @test val(neue) ≈ first(result[]) / load*1e6
     @test stderror(neue) ≈ last(result[]) / sqrt(DD.nsamples) / load*1e6
 
-    cvar = CVAR(energyunit, result, alpha)
+    cvar = CVAR(:energy, result, alpha)
     estimate = result.shortfall_samples;
-    tail_losses = estimate[estimate .>= quantile(estimate, alpha)];
+    tail_losses = estimate[estimate .> quantile(estimate, alpha)];
     @test val(cvar) ≈ mean(tail_losses)
     @test stderror(cvar) ≈ std(tail_losses) / sqrt(length(tail_losses))
 
@@ -59,7 +58,7 @@
     @test val(region_neue) ≈ first(result[r]) / load*1e6
     @test stderror(region_neue) ≈ last(result[r]) / sqrt(DD.nsamples) / load*1e6
 
-    region_cvar = CVAR(energyunit, result, alpha, r)
+    region_cvar = CVAR(:energy, result, alpha, r)
     region_estimate = result.shortfall_region_samples[r_idx, :];
     region_tail_losses = region_estimate[region_estimate .>= quantile(region_estimate, alpha)];
     @test val(region_cvar) ≈ mean(region_tail_losses)
@@ -73,8 +72,9 @@
     @test_throws BoundsError LOLE(result, r_bad)
     @test_throws BoundsError EUE(result, r_bad)
     @test_throws BoundsError NEUE(result, r_bad)
-    @test_throws BoundsError CVAR(energyunit,result, alpha, r_bad)
+    @test_throws BoundsError CVAR(:energy,result, alpha, r_bad)
     @test_throws BoundsError NCVAR(result, region_cvar, r_bad)
+    @test_throws ArgumentError CVAR(:power, result, alpha)
 
     # Period-specific
 
@@ -87,6 +87,8 @@
     period_eue = EUE(result, t)
     @test val(period_eue) ≈ first(result[t])
     @test stderror(period_eue) ≈ last(result[t]) / sqrt(DD.nsamples)
+
+    @test_throws ArgumentError CVAR(:energy, result, alpha, DD.periods)
 
     @test_throws BoundsError result[t_bad]
     @test_throws BoundsError LOLE(result, t_bad)
@@ -125,9 +127,8 @@ end
 
     N = DD.nperiods
     r, r_idx, r_bad = DD.testresource, DD.testresource_idx, DD.notaresource
-    t, t_idx, t_bad = DD.testperiod, DD.testperiod_idx, DD.notaperiod
+    t, t_idx, t_bad, badperiods = DD.testperiod, DD.testperiod_idx, DD.notaperiod, DD.badperiods
     alpha = 0.95
-    energyunit = MWh
 
     result = PRASCore.Results.ShortfallSamplesResult{N,1,Hour,MW,MWh,ShortfallSamples}(
         Regions{N,MW}(DD.resourcenames, DD.resource_vals), DD.periods, DD.d)
@@ -151,7 +152,7 @@ end
     @test val(neue) ≈ mean(result[]) / load*1e6
     @test stderror(neue) ≈ std(result[]) / sqrt(DD.nsamples) / load*1e6
 
-    ue_cvar = CVAR(energyunit, result, alpha)
+    ue_cvar = CVAR(:energy, result, alpha)
     estimate = result[];
     tail_losses = estimate[estimate .>= quantile(estimate, alpha)];
     @test val(ue_cvar) ≈ mean(tail_losses)
@@ -180,7 +181,7 @@ end
     @test val(region_neue) ≈ mean(result[r]) / load*1e6
     @test stderror(region_neue) ≈ std(result[r]) / sqrt(DD.nsamples) / load*1e6
 
-    region_ue_cvar = CVAR(energyunit, result, alpha, r)
+    region_ue_cvar = CVAR(:energy, result, alpha, r)
     region_estimate = result[r];
     region_tail_losses = region_estimate[region_estimate .>= quantile(region_estimate, alpha)];
     @test val(region_ue_cvar) ≈ mean(region_tail_losses)
@@ -194,7 +195,7 @@ end
     @test_throws BoundsError LOLE(result, r_bad)
     @test_throws BoundsError EUE(result, r_bad)
     @test_throws BoundsError NEUE(result, r_bad)
-    @test_throws BoundsError CVAR(energyunit, result, alpha, r_bad)
+    @test_throws BoundsError CVAR(:energy, result, alpha, r_bad)
     @test_throws BoundsError NCVAR(result, region_ue_cvar, r_bad)
 
     # Period-specific
@@ -211,16 +212,16 @@ end
     @test val(period_eue) ≈ mean(result[t])
     @test stderror(period_eue) ≈ std(result[t]) / sqrt(DD.nsamples)
 
-    period_cvar = CVAR(energyunit, result, alpha, t)
-    period_estimate = result[t];
-    period_tail_losses = period_estimate[period_estimate .>= quantile(period_estimate, alpha)];
+    period_cvar = CVAR(:energy, result, alpha, DD.periods)
+    period_estimate = result[DD.periods];
+    period_tail_losses = period_estimate[period_estimate .> quantile(period_estimate, alpha)];
     @test val(period_cvar) ≈ mean(period_tail_losses)
     @test stderror(period_cvar) ≈ std(period_tail_losses) / sqrt(length(period_tail_losses))
 
     @test_throws BoundsError result[t_bad]
     @test_throws BoundsError LOLE(result, t_bad)
     @test_throws BoundsError EUE(result, t_bad)
-    @test_throws BoundsError CVAR(energyunit, result, alpha, t_bad)
+    @test_throws BoundsError CVAR(:energy, result, alpha, badperiods)
 
     # Region + period-specific
 
@@ -237,7 +238,7 @@ end
     @test val(regionperiod_eue) ≈ mean(result[r, t])
     @test stderror(regionperiod_eue) ≈ std(result[r, t]) / sqrt(DD.nsamples)
 
-    regionperiod_cvar = CVAR(energyunit, result, alpha, r, t)
+    regionperiod_cvar = CVAR(:energy, result, alpha, r, t)
     regionperiod_estimate = result[r, t];
     regionperiod_tail_losses = regionperiod_estimate[regionperiod_estimate .>= quantile(regionperiod_estimate, alpha)];
     @test val(regionperiod_cvar) ≈ mean(regionperiod_tail_losses)
@@ -255,8 +256,8 @@ end
     @test_throws BoundsError EUE(result, r_bad, t)
     @test_throws BoundsError EUE(result, r_bad, t_bad)
 
-    @test_throws BoundsError CVAR(energyunit, result, alpha, r, t_bad)
-    @test_throws BoundsError CVAR(energyunit, result, alpha, r_bad, t)
-    @test_throws BoundsError CVAR(energyunit, result, alpha, r_bad, t_bad)
+    @test_throws BoundsError CVAR(:energy, result, alpha, r, t_bad)
+    @test_throws BoundsError CVAR(:energy, result, alpha, r_bad, t)
+    @test_throws BoundsError CVAR(:energy, result, alpha, r_bad, t_bad)
 
 end

--- a/PRASCore.jl/test/Results/shortfall.jl
+++ b/PRASCore.jl/test/Results/shortfall.jl
@@ -100,6 +100,7 @@ end
     N = DD.nperiods
     r, r_idx, r_bad = DD.testresource, DD.testresource_idx, DD.notaresource
     t, t_idx, t_bad = DD.testperiod, DD.testperiod_idx, DD.notaperiod
+    alpha = 0.95
 
     result = PRASCore.Results.ShortfallSamplesResult{N,1,Hour,MW,MWh,ShortfallSamples}(
         Regions{N,MW}(DD.resourcenames, DD.resource_vals), DD.periods, DD.d)
@@ -123,6 +124,16 @@ end
     @test val(neue) ≈ mean(result[]) / load*1e6
     @test stderror(neue) ≈ std(result[]) / sqrt(DD.nsamples) / load*1e6
 
+    cvar = CVAR(result, alpha)
+    estimate = result[];
+    tail_losses = estimate[estimate .>= quantile(estimate, alpha)];
+    @test val(cvar) ≈ mean(tail_losses)
+    @test stderror(cvar) ≈ std(tail_losses) / sqrt(length(tail_losses))
+
+    ncvar = NCVAR(result, cvar)
+    @test val(ncvar) ≈ val(cvar) / load*1e6
+    @test stderror(ncvar) ≈ stderror(cvar) / load*1e6
+
     # Region-specific
 
     @test length(result[r]) == DD.nsamples
@@ -142,10 +153,22 @@ end
     @test val(region_neue) ≈ mean(result[r]) / load*1e6
     @test stderror(region_neue) ≈ std(result[r]) / sqrt(DD.nsamples) / load*1e6
 
+    region_cvar = CVAR(result, alpha, r)
+    region_estimate = result[r];
+    region_tail_losses = region_estimate[region_estimate .>= quantile(region_estimate, alpha)];
+    @test val(region_cvar) ≈ mean(region_tail_losses)
+    @test stderror(region_cvar) ≈ std(region_tail_losses) / sqrt(length(region_tail_losses))
+
+    region_ncvar = NCVAR(result, region_cvar, r)
+    @test val(region_ncvar) ≈ val(region_cvar) / load*1e6
+    @test stderror(region_ncvar) ≈ stderror(region_cvar) / load*1e6
+
     @test_throws BoundsError result[r_bad]
     @test_throws BoundsError LOLE(result, r_bad)
     @test_throws BoundsError EUE(result, r_bad)
     @test_throws BoundsError NEUE(result, r_bad)
+    @test_throws BoundsError CVAR(result, alpha, r_bad)
+    @test_throws BoundsError NCVAR(result, region_cvar, r_bad)
 
     # Period-specific
 
@@ -161,9 +184,16 @@ end
     @test val(period_eue) ≈ mean(result[t])
     @test stderror(period_eue) ≈ std(result[t]) / sqrt(DD.nsamples)
 
+    period_cvar = CVAR(result, alpha, t)
+    period_estimate = result[t];
+    period_tail_losses = period_estimate[period_estimate .>= quantile(period_estimate, alpha)];
+    @test val(period_cvar) ≈ mean(period_tail_losses)
+    @test stderror(period_cvar) ≈ std(period_tail_losses) / sqrt(length(period_tail_losses))
+
     @test_throws BoundsError result[t_bad]
     @test_throws BoundsError LOLE(result, t_bad)
     @test_throws BoundsError EUE(result, t_bad)
+    @test_throws BoundsError CVAR(result, alpha, t_bad)
 
     # Region + period-specific
 
@@ -180,6 +210,12 @@ end
     @test val(regionperiod_eue) ≈ mean(result[r, t])
     @test stderror(regionperiod_eue) ≈ std(result[r, t]) / sqrt(DD.nsamples)
 
+    regionperiod_cvar = CVAR(result, alpha, r, t)
+    regionperiod_estimate = result[r, t];
+    regionperiod_tail_losses = regionperiod_estimate[regionperiod_estimate .>= quantile(regionperiod_estimate, alpha)];
+    @test val(regionperiod_cvar) ≈ mean(regionperiod_tail_losses)
+    @test stderror(regionperiod_cvar) ≈ std(regionperiod_tail_losses) / sqrt(length(regionperiod_tail_losses))
+
     @test_throws BoundsError result[r, t_bad]
     @test_throws BoundsError result[r_bad, t]
     @test_throws BoundsError result[r_bad, t_bad]
@@ -191,5 +227,9 @@ end
     @test_throws BoundsError EUE(result, r, t_bad)
     @test_throws BoundsError EUE(result, r_bad, t)
     @test_throws BoundsError EUE(result, r_bad, t_bad)
+
+    @test_throws BoundsError CVAR(result, alpha, r, t_bad)
+    @test_throws BoundsError CVAR(result, alpha, r_bad, t)
+    @test_throws BoundsError CVAR(result, alpha, r_bad, t_bad)
 
 end

--- a/PRASCore.jl/test/Results/shortfall.jl
+++ b/PRASCore.jl/test/Results/shortfall.jl
@@ -5,6 +5,7 @@
     r, r_idx, r_bad = DD.testresource, DD.testresource_idx, DD.notaresource
     t, t_idx, t_bad = DD.testperiod, DD.testperiod_idx, DD.notaperiod
     alpha = DD.alpha
+    energyunit = MWh
 
     result = PRASCore.Results.ShortfallResult{N,1,Hour,MWh,Shortfall}(
         DD.nsamples, Regions{N,MW}(DD.resourcenames, DD.resource_vals), DD.periods,
@@ -31,19 +32,11 @@
     @test val(neue) ≈ first(result[]) / load*1e6
     @test stderror(neue) ≈ last(result[]) / sqrt(DD.nsamples) / load*1e6
 
-    cvar = CVAR(result, alpha)
+    cvar = CVAR(energyunit, result, alpha)
     estimate = result.shortfall_samples;
     tail_losses = estimate[estimate .>= quantile(estimate, alpha)];
     @test val(cvar) ≈ mean(tail_losses)
     @test stderror(cvar) ≈ std(tail_losses) / sqrt(length(tail_losses))
-
-    capacity_cvar = cvar.capacity_cvar
-    cap_shortfal = vec(reshape(result.capacity_shortfall_mean, 1, :))
-    var = quantile(cap_shortfal, alpha)
-    tail_losses = cap_shortfal[cap_shortfal .>= var]
-    capacity_cvar_check = mean(tail_losses)
-    @test val(capacity_cvar) ≈ capacity_cvar_check
-    @test stderror(capacity_cvar) ≈ std(tail_losses) / sqrt(length(tail_losses))
 
     ncvar = NCVAR(result, cvar)
     @test val(ncvar) ≈ val(cvar) / load*1e6
@@ -66,19 +59,11 @@
     @test val(region_neue) ≈ first(result[r]) / load*1e6
     @test stderror(region_neue) ≈ last(result[r]) / sqrt(DD.nsamples) / load*1e6
 
-    region_cvar = CVAR(result, alpha, r)
+    region_cvar = CVAR(energyunit, result, alpha, r)
     region_estimate = result.shortfall_region_samples[r_idx, :];
     region_tail_losses = region_estimate[region_estimate .>= quantile(region_estimate, alpha)];
     @test val(region_cvar) ≈ mean(region_tail_losses)
     @test stderror(region_cvar) ≈ std(region_tail_losses) / sqrt(length(region_tail_losses))
-
-    region_capacity_cvar = region_cvar.capacity_cvar
-    region_cap_shortfal = result.capacity_shortfall_mean[r_idx, :]
-    var = quantile(region_cap_shortfal, alpha)
-    tail_losses = region_cap_shortfal[region_cap_shortfal .>= var]
-    region_capacity_cvar_check = mean(tail_losses)
-    @test val(region_capacity_cvar) ≈ region_capacity_cvar_check
-    @test stderror(region_capacity_cvar) ≈ std(tail_losses) / sqrt(length(tail_losses))
 
     region_ncvar = NCVAR(result, region_cvar, r)
     @test val(region_ncvar) ≈ val(region_cvar) / load*1e6
@@ -88,7 +73,7 @@
     @test_throws BoundsError LOLE(result, r_bad)
     @test_throws BoundsError EUE(result, r_bad)
     @test_throws BoundsError NEUE(result, r_bad)
-    @test_throws BoundsError CVAR(result, alpha, r_bad)
+    @test_throws BoundsError CVAR(energyunit,result, alpha, r_bad)
     @test_throws BoundsError NCVAR(result, region_cvar, r_bad)
 
     # Period-specific
@@ -142,6 +127,7 @@ end
     r, r_idx, r_bad = DD.testresource, DD.testresource_idx, DD.notaresource
     t, t_idx, t_bad = DD.testperiod, DD.testperiod_idx, DD.notaperiod
     alpha = 0.95
+    energyunit = MWh
 
     result = PRASCore.Results.ShortfallSamplesResult{N,1,Hour,MW,MWh,ShortfallSamples}(
         Regions{N,MW}(DD.resourcenames, DD.resource_vals), DD.periods, DD.d, DD.cap_d)
@@ -165,23 +151,15 @@ end
     @test val(neue) ≈ mean(result[]) / load*1e6
     @test stderror(neue) ≈ std(result[]) / sqrt(DD.nsamples) / load*1e6
 
-    cvar = CVAR(result, alpha)
+    ue_cvar = CVAR(energyunit, result, alpha)
     estimate = result[];
     tail_losses = estimate[estimate .>= quantile(estimate, alpha)];
-    @test val(cvar) ≈ mean(tail_losses)
-    @test stderror(cvar) ≈ std(tail_losses) / sqrt(length(tail_losses))
+    @test val(ue_cvar) ≈ mean(tail_losses)
+    @test stderror(ue_cvar) ≈ std(tail_losses) / sqrt(length(tail_losses))
 
-    capacity_cvar = cvar.capacity_cvar
-    cap_shortfal = vec(reshape(result.capacity_shortfall, 1, :))
-    var = quantile(cap_shortfal, alpha)
-    tail_losses = cap_shortfal[cap_shortfal .>= var]
-    capacity_cvar_check = mean(tail_losses)
-    @test val(capacity_cvar) ≈ capacity_cvar_check
-    @test stderror(capacity_cvar) ≈ std(tail_losses) / sqrt(length(tail_losses))
-
-    ncvar = NCVAR(result, cvar)
-    @test val(ncvar) ≈ val(cvar) / load*1e6
-    @test stderror(ncvar) ≈ stderror(cvar) / load*1e6
+    ncvar = NCVAR(result, ue_cvar)
+    @test val(ncvar) ≈ val(ue_cvar) / load*1e6
+    @test stderror(ncvar) ≈ stderror(ue_cvar) / load*1e6
 
     # Region-specific
 
@@ -202,30 +180,22 @@ end
     @test val(region_neue) ≈ mean(result[r]) / load*1e6
     @test stderror(region_neue) ≈ std(result[r]) / sqrt(DD.nsamples) / load*1e6
 
-    region_cvar = CVAR(result, alpha, r)
+    region_ue_cvar = CVAR(energyunit, result, alpha, r)
     region_estimate = result[r];
     region_tail_losses = region_estimate[region_estimate .>= quantile(region_estimate, alpha)];
-    @test val(region_cvar) ≈ mean(region_tail_losses)
-    @test stderror(region_cvar) ≈ std(region_tail_losses) / sqrt(length(region_tail_losses))
+    @test val(region_ue_cvar) ≈ mean(region_tail_losses)
+    @test stderror(region_ue_cvar) ≈ std(region_tail_losses) / sqrt(length(region_tail_losses))
 
-    region_capacity_cvar = region_cvar.capacity_cvar
-    region_cap_shortfal = result.capacity_shortfall[r_idx, :]
-    var = quantile(region_cap_shortfal, alpha)
-    tail_losses = region_cap_shortfal[region_cap_shortfal .>= var]
-    region_capacity_cvar_check = mean(tail_losses)
-    @test val(region_capacity_cvar) ≈ region_capacity_cvar_check
-    @test stderror(region_capacity_cvar) ≈ std(tail_losses) / sqrt(length(tail_losses))
-
-    region_ncvar = NCVAR(result, region_cvar, r)
-    @test val(region_ncvar) ≈ val(region_cvar) / load*1e6
-    @test stderror(region_ncvar) ≈ stderror(region_cvar) / load*1e6
+    region_ncvar = NCVAR(result, region_ue_cvar, r)
+    @test val(region_ncvar) ≈ val(region_ue_cvar) / load*1e6
+    @test stderror(region_ncvar) ≈ stderror(region_ue_cvar) / load*1e6
 
     @test_throws BoundsError result[r_bad]
     @test_throws BoundsError LOLE(result, r_bad)
     @test_throws BoundsError EUE(result, r_bad)
     @test_throws BoundsError NEUE(result, r_bad)
-    @test_throws BoundsError CVAR(result, alpha, r_bad)
-    @test_throws BoundsError NCVAR(result, region_cvar, r_bad)
+    @test_throws BoundsError CVAR(energyunit, result, alpha, r_bad)
+    @test_throws BoundsError NCVAR(result, region_ue_cvar, r_bad)
 
     # Period-specific
 
@@ -241,7 +211,7 @@ end
     @test val(period_eue) ≈ mean(result[t])
     @test stderror(period_eue) ≈ std(result[t]) / sqrt(DD.nsamples)
 
-    period_cvar = CVAR(result, alpha, t)
+    period_cvar = CVAR(energyunit, result, alpha, t)
     period_estimate = result[t];
     period_tail_losses = period_estimate[period_estimate .>= quantile(period_estimate, alpha)];
     @test val(period_cvar) ≈ mean(period_tail_losses)
@@ -250,7 +220,7 @@ end
     @test_throws BoundsError result[t_bad]
     @test_throws BoundsError LOLE(result, t_bad)
     @test_throws BoundsError EUE(result, t_bad)
-    @test_throws BoundsError CVAR(result, alpha, t_bad)
+    @test_throws BoundsError CVAR(energyunit, result, alpha, t_bad)
 
     # Region + period-specific
 
@@ -267,7 +237,7 @@ end
     @test val(regionperiod_eue) ≈ mean(result[r, t])
     @test stderror(regionperiod_eue) ≈ std(result[r, t]) / sqrt(DD.nsamples)
 
-    regionperiod_cvar = CVAR(result, alpha, r, t)
+    regionperiod_cvar = CVAR(energyunit, result, alpha, r, t)
     regionperiod_estimate = result[r, t];
     regionperiod_tail_losses = regionperiod_estimate[regionperiod_estimate .>= quantile(regionperiod_estimate, alpha)];
     @test val(regionperiod_cvar) ≈ mean(regionperiod_tail_losses)
@@ -285,8 +255,8 @@ end
     @test_throws BoundsError EUE(result, r_bad, t)
     @test_throws BoundsError EUE(result, r_bad, t_bad)
 
-    @test_throws BoundsError CVAR(result, alpha, r, t_bad)
-    @test_throws BoundsError CVAR(result, alpha, r_bad, t)
-    @test_throws BoundsError CVAR(result, alpha, r_bad, t_bad)
+    @test_throws BoundsError CVAR(energyunit, result, alpha, r, t_bad)
+    @test_throws BoundsError CVAR(energyunit, result, alpha, r_bad, t)
+    @test_throws BoundsError CVAR(energyunit, result, alpha, r_bad, t_bad)
 
 end

--- a/PRASCore.jl/test/Results/shortfall.jl
+++ b/PRASCore.jl/test/Results/shortfall.jl
@@ -4,13 +4,15 @@
     N = DD.nperiods
     r, r_idx, r_bad = DD.testresource, DD.testresource_idx, DD.notaresource
     t, t_idx, t_bad = DD.testperiod, DD.testperiod_idx, DD.notaperiod
+    alpha = DD.alpha
 
     result = PRASCore.Results.ShortfallResult{N,1,Hour,MWh,Shortfall}(
         DD.nsamples, Regions{N,MW}(DD.resourcenames, DD.resource_vals), DD.periods,
         DD.d1, DD.d2, DD.d1_resource, DD.d2_resource,
         DD.d1_period, DD.d2_period, DD.d1_resourceperiod, DD.d2_resourceperiod,
         DD.d3_resourceperiod,
-        DD.d4, DD.d4_resource, DD.d4_period, DD.d4_resourceperiod)
+        DD.d4, DD.d4_resource, DD.d4_period, DD.d4_resourceperiod,
+        DD.d1_sample, DD.d1_resourcesample)
 
     # Overall
 
@@ -28,6 +30,17 @@
     load = sum(DD.resource_vals)
     @test val(neue) ≈ first(result[]) / load*1e6
     @test stderror(neue) ≈ last(result[]) / sqrt(DD.nsamples) / load*1e6
+
+    cvar = CVAR(result, alpha)
+    estimate = result.shortfall_samples;
+    tail_losses = estimate[estimate .>= quantile(estimate, alpha)];
+    @test val(cvar) ≈ mean(tail_losses)
+    @test stderror(cvar) ≈ std(tail_losses) / sqrt(length(tail_losses))
+
+    ncvar = NCVAR(result, cvar)
+    @test val(ncvar) ≈ val(cvar) / load*1e6
+    @test stderror(ncvar) ≈ stderror(cvar) / load*1e6
+
     # Region-specific
 
     @test result[r] ≈ (sum(DD.d3_resourceperiod[r_idx,:]), DD.d4_resource[r_idx])
@@ -45,10 +58,22 @@
     @test val(region_neue) ≈ first(result[r]) / load*1e6
     @test stderror(region_neue) ≈ last(result[r]) / sqrt(DD.nsamples) / load*1e6
 
+    region_cvar = CVAR(result, alpha, r)
+    region_estimate = result.shortfall_region_samples[r_idx, :];
+    region_tail_losses = region_estimate[region_estimate .>= quantile(region_estimate, alpha)];
+    @test val(region_cvar) ≈ mean(region_tail_losses)
+    @test stderror(region_cvar) ≈ std(region_tail_losses) / sqrt(length(region_tail_losses))
+
+    region_ncvar = NCVAR(result, region_cvar, r)
+    @test val(region_ncvar) ≈ val(region_cvar) / load*1e6
+    @test stderror(region_ncvar) ≈ stderror(region_cvar) / load*1e6
+
     @test_throws BoundsError result[r_bad]
     @test_throws BoundsError LOLE(result, r_bad)
     @test_throws BoundsError EUE(result, r_bad)
     @test_throws BoundsError NEUE(result, r_bad)
+    @test_throws BoundsError CVAR(result, alpha, r_bad)
+    @test_throws BoundsError NCVAR(result, region_cvar, r_bad)
 
     # Period-specific
 

--- a/PRASCore.jl/test/Simulations/runtests.jl
+++ b/PRASCore.jl/test/Simulations/runtests.jl
@@ -5,7 +5,8 @@
     end
 
     nstderr_tol = 3
-    alpha = 0.95    
+    alpha = 0.95
+    energyunit = MWh    
 
     simspec = SequentialMonteCarlo(samples=100_000, seed=1, threaded=false)
     smallsample = SequentialMonteCarlo(samples=10, seed=123, threaded=false)
@@ -67,7 +68,7 @@
                           TestData.singlenode_a_lole, nstderr_tol)
         @test withinrange(EUE(shortfall_1a),
                           TestData.singlenode_a_eue, nstderr_tol)
-        @test withinrange(CVAR(shortfall_1a, alpha),
+        @test withinrange(CVAR(energyunit, shortfall_1a, alpha),
                           TestData.singlenode_a_cvar, nstderr_tol)                          
         @test withinrange(LOLE(shortfall_1a, "Region"),
                           TestData.singlenode_a_lole, nstderr_tol)
@@ -137,13 +138,13 @@
                           TestData.singlenode_b_lole, nstderr_tol)
         @test withinrange(EUE(shortfall_1b),
                           TestData.singlenode_b_eue, nstderr_tol)
-        @test withinrange(CVAR(shortfall_1b, alpha),
+        @test withinrange(CVAR(energyunit, shortfall_1b, alpha),
                           TestData.singlenode_b_cvar, nstderr_tol)                          
         @test withinrange(LOLE(shortfall_1b, "Region"),
                           TestData.singlenode_b_lole, nstderr_tol)
         @test withinrange(EUE(shortfall_1b, "Region"),
                           TestData.singlenode_b_eue, nstderr_tol)
-        @test withinrange(CVAR(shortfall_1b, alpha, "Region"),
+        @test withinrange(CVAR(energyunit, shortfall_1b, alpha, "Region"),
                           TestData.singlenode_b_cvar, nstderr_tol)                                                    
 
         @test all(LOLE.(shortfall_1b, timestamps_b) .≈

--- a/PRASCore.jl/test/Simulations/runtests.jl
+++ b/PRASCore.jl/test/Simulations/runtests.jl
@@ -6,7 +6,6 @@
 
     nstderr_tol = 3
     alpha = 0.95
-    energyunit = MWh    
 
     simspec = SequentialMonteCarlo(samples=100_000, seed=1, threaded=false)
     smallsample = SequentialMonteCarlo(samples=10, seed=123, threaded=false)
@@ -68,7 +67,7 @@
                           TestData.singlenode_a_lole, nstderr_tol)
         @test withinrange(EUE(shortfall_1a),
                           TestData.singlenode_a_eue, nstderr_tol)
-        @test withinrange(CVAR(energyunit, shortfall_1a, alpha),
+        @test withinrange(CVAR(:energy, shortfall_1a, alpha),
                           TestData.singlenode_a_cvar, nstderr_tol)                          
         @test withinrange(LOLE(shortfall_1a, "Region"),
                           TestData.singlenode_a_lole, nstderr_tol)
@@ -138,13 +137,13 @@
                           TestData.singlenode_b_lole, nstderr_tol)
         @test withinrange(EUE(shortfall_1b),
                           TestData.singlenode_b_eue, nstderr_tol)
-        @test withinrange(CVAR(energyunit, shortfall_1b, alpha),
+        @test withinrange(CVAR(:energy, shortfall_1b, alpha),
                           TestData.singlenode_b_cvar, nstderr_tol)                          
         @test withinrange(LOLE(shortfall_1b, "Region"),
                           TestData.singlenode_b_lole, nstderr_tol)
         @test withinrange(EUE(shortfall_1b, "Region"),
                           TestData.singlenode_b_eue, nstderr_tol)
-        @test withinrange(CVAR(energyunit, shortfall_1b, alpha, "Region"),
+        @test withinrange(CVAR(:energy, shortfall_1b, alpha, "Region"),
                           TestData.singlenode_b_cvar, nstderr_tol)                                                    
 
         @test all(LOLE.(shortfall_1b, timestamps_b) .≈

--- a/PRASCore.jl/test/Simulations/runtests.jl
+++ b/PRASCore.jl/test/Simulations/runtests.jl
@@ -5,6 +5,7 @@
     end
 
     nstderr_tol = 3
+    alpha = 0.95    
 
     simspec = SequentialMonteCarlo(samples=100_000, seed=1, threaded=false)
     smallsample = SequentialMonteCarlo(samples=10, seed=123, threaded=false)
@@ -66,6 +67,8 @@
                           TestData.singlenode_a_lole, nstderr_tol)
         @test withinrange(EUE(shortfall_1a),
                           TestData.singlenode_a_eue, nstderr_tol)
+        @test withinrange(CVAR(shortfall_1a, alpha),
+                          TestData.singlenode_a_cvar, nstderr_tol)                          
         @test withinrange(LOLE(shortfall_1a, "Region"),
                           TestData.singlenode_a_lole, nstderr_tol)
         @test withinrange(EUE(shortfall_1a, "Region"),
@@ -134,10 +137,14 @@
                           TestData.singlenode_b_lole, nstderr_tol)
         @test withinrange(EUE(shortfall_1b),
                           TestData.singlenode_b_eue, nstderr_tol)
+        @test withinrange(CVAR(shortfall_1b, alpha),
+                          TestData.singlenode_b_cvar, nstderr_tol)                          
         @test withinrange(LOLE(shortfall_1b, "Region"),
                           TestData.singlenode_b_lole, nstderr_tol)
         @test withinrange(EUE(shortfall_1b, "Region"),
                           TestData.singlenode_b_eue, nstderr_tol)
+        @test withinrange(CVAR(shortfall_1b, alpha, "Region"),
+                          TestData.singlenode_b_cvar, nstderr_tol)                                                    
 
         @test all(LOLE.(shortfall_1b, timestamps_b) .≈
                   LOLE.(shortfall2_1b, timestamps_b))

--- a/PRASCore.jl/test/dummydata.jl
+++ b/PRASCore.jl/test/dummydata.jl
@@ -6,6 +6,7 @@ using TimeZones
 const tz = tz"UTC"
 
 nsamples = 100
+alpha = 0.95
 
 resourcenames = ["A", "B", "C"]
 nresources = length(resourcenames)
@@ -32,6 +33,8 @@ d1 = rand()
 d1_resource = rand(nresources)
 d1_period = rand(nperiods)
 d1_resourceperiod = rand(nresources, nperiods)
+d1_sample = rand(0:999, nsamples)
+d1_resourcesample = rand(0:999, nresources, nsamples)
 
 d2 = rand()
 d2_resource = rand(nresources)

--- a/PRASCore.jl/test/dummydata.jl
+++ b/PRASCore.jl/test/dummydata.jl
@@ -21,6 +21,7 @@ testinterface = interfacenames[testinterface_idx]
 notaninterface = "X"=>"Y"
 
 periods = ZonedDateTime(2012,4,1,0,tz):Hour(1):ZonedDateTime(2012,4,7,23,tz)
+badperiods = ZonedDateTime(2013,4,1,0,tz):Hour(1):ZonedDateTime(2013,4,7,23,tz)
 nperiods = length(periods)
 resource_vals = rand(0:999, nresources, nperiods)
 testperiod_idx = 29

--- a/PRASCore.jl/test/dummydata.jl
+++ b/PRASCore.jl/test/dummydata.jl
@@ -28,7 +28,6 @@ testperiod = periods[testperiod_idx]
 notaperiod = ZonedDateTime(2010,1,1,0,tz)
 
 d = rand(0:999, nresources, nperiods, nsamples)
-cap_d = rand(0:999, nresources, nsamples)
 
 d1 = rand()
 d1_resource = rand(nresources)

--- a/PRASCore.jl/test/dummydata.jl
+++ b/PRASCore.jl/test/dummydata.jl
@@ -28,13 +28,14 @@ testperiod = periods[testperiod_idx]
 notaperiod = ZonedDateTime(2010,1,1,0,tz)
 
 d = rand(0:999, nresources, nperiods, nsamples)
+cap_d = rand(0:999, nresources, nsamples)
 
 d1 = rand()
 d1_resource = rand(nresources)
 d1_period = rand(nperiods)
 d1_resourceperiod = rand(nresources, nperiods)
-d1_sample = rand(0:999, nsamples)
-d1_resourcesample = rand(0:999, nresources, nsamples)
+d1_sample = rand(nsamples) * 999
+d1_resourcesample = rand(nresources, nsamples) * 999
 
 d2 = rand()
 d2_resource = rand(nresources)

--- a/docs/src/PRAS/results.md
+++ b/docs/src/PRAS/results.md
@@ -109,7 +109,7 @@ horizon can be extracted as:
 shortfall, = assess(sys, SequentialMonteCarlo(), Shortfall())
 eue_overall = EUE(shortfall)
 lole_overall = LOLE(shortfall)
-ue_cvar_overall = CVAR(MWh, shortfall, 0.95)
+ue_cvar_overall = CVAR(:energy, shortfall, 0.95)
 ```
 
 More specific metrics can be obtained as well:

--- a/docs/src/PRAS/results.md
+++ b/docs/src/PRAS/results.md
@@ -100,7 +100,7 @@ the total shortfall across all regions and time periods.
 
 Shortfall results are unique among the built-in result types in that the raw
 results can also be converted to specific probabilistic risk metrics
-(**EUE** and **LOLE**). For sampling-based methods, both metric
+(**EUE**,  **LOLE**, or **CVAR**). For sampling-based methods, both metric
 estimates and the standard error of those estimates are provided. For example,
 after assessing the system, metrics across all regions and the full simulation
 horizon can be extracted as:
@@ -109,6 +109,7 @@ horizon can be extracted as:
 shortfall, = assess(sys, SequentialMonteCarlo(), Shortfall())
 eue_overall = EUE(shortfall)
 lole_overall = LOLE(shortfall)
+ue_cvar_overall = CVAR(MWh, shortfall, 0.95)
 ```
 
 More specific metrics can be obtained as well:

--- a/docs/src/PRASCore/api.md
+++ b/docs/src/PRASCore/api.md
@@ -42,4 +42,6 @@ PRASCore.Results.DemandResponseAvailability
 PRASCore.Results.DemandResponseEnergy
 PRASCore.Results.DemandResponseEnergySamples
 PRASCore.Results.LineAvailability
+PRASCore.Results.CVAR
+PRASCore.Results.NCVAR
 ```


### PR DESCRIPTION
## Summary

This PR adds the Conditional Value at Risk (CVAR) metric to quantify tail-risk shortfalls in resource adequacy assessments. CVAR measures the expected unserved energy across the worst (1−α) simulation samples, where α is a user-defined confidence level (e.g., 0.95).

This PR implements CVAR for unserved energy on both `ShortfallResult` and `ShortfallSamplesResult`. CVAR for other dimensions (duration, magnitude) is out of scope and left for a follow-up.

## Methodology

CVAR is computed as the weighted average of total unserved energy samples that exceed the α-th percentile (VAR). For `ShortfallResult`, an additional vector of per-sample total unserved energy is accumulated during simulation and discarded after CVAR computation (Type 1 in figure below).

## implementation

```julia
alpha = 0.95
ue_cvar  = CVAR(:energy, shortfall, alpha) # system-level
ue_ncvar = NCVAR(shortfall, cvar) # normalized by demand
regional_ue_cvar = CVAR.(:energy, shortfall, alpha, sys.regions.names)
```

<img width="1863" height="775" alt="Screenshot 2026-02-23 at 12 52 37 PM" src="https://github.com/user-attachments/assets/fa87abb1-f553-40a1-98ce-425939db2ea3" />

**Performance testing**

- Tested the increase in memory and computation time using `@benchmark` testing for `Shortfall` and `ShortfallSamples`. There is a slight increase in memory use in the `Shortfall` due to the additional vector storing the total unserved energy across all samples. 
<img width="1333" height="716" alt="Screenshot 2026-04-03 at 9 52 05 AM" src="https://github.com/user-attachments/assets/1c4d66ca-948a-4670-b7ea-37b50e6ca38c" />

 


