### PR TITLE
New risk metrics and events

### DIFF
--- a/PRASCore.jl/src/Results/Results.jl
+++ b/PRASCore.jl/src/Results/Results.jl
@@ -5,6 +5,7 @@ import OnlineStats: Series
 import OnlineStatsBase: EqualWeight, Mean, Variance, value
 import Printf: @sprintf
 import StatsBase: mean, std, stderror
+import Dates: Date
 
 import ..Systems: SystemModel, ZonedDateTime, Period,
                   PowerUnit, EnergyUnit, conversionfactor,
@@ -12,7 +13,7 @@ import ..Systems: SystemModel, ZonedDateTime, Period,
 export
 
     # Metrics
-    ReliabilityMetric, LOLE, EUE, NEUE,
+    ReliabilityMetric, LOLE, EUE, NEUE, LOLD,
     val, stderror,
 
     # Result specifications

--- a/PRASCore.jl/src/Results/Results.jl
+++ b/PRASCore.jl/src/Results/Results.jl
@@ -13,7 +13,7 @@ import ..Systems: SystemModel, ZonedDateTime, Period,
 export
 
     # Metrics
-    ReliabilityMetric, LOLE, EUE, NEUE, LOLD,
+    ReliabilityMetric, LOLE, EUE, NEUE, LOLD, LOLEv,
     val, stderror,
 
     # Result specifications
@@ -26,7 +26,7 @@ export
     DemandResponseEnergy, DemandResponseEnergySamples,
     GeneratorAvailability, StorageAvailability,
     GeneratorStorageAvailability,DemandResponseAvailability,
-    LineAvailability
+    LineAvailability, ShortfallEvents
 
 include("utils.jl")
 include("metrics.jl")
@@ -167,12 +167,17 @@ getindex(x::AbstractEnergyResult, name::String, ::Colon) =
 getindex(x::AbstractEnergyResult, ::Colon, ::Colon) =
     getindex.(x, names(x), permutedims(x.timestamps))
 
+
+abstract type AbstractShortfallEventResult{N,L,T} <: Result{N,L,T} end
+
+
 include("StorageEnergy.jl")
 include("GeneratorStorageEnergy.jl")
 include("DemandResponseEnergy.jl")
 include("StorageEnergySamples.jl")
 include("GeneratorStorageEnergySamples.jl")
 include("DemandResponseEnergySamples.jl")
+include("ShortfallEvents.jl")
 
 function resultchannel(
     results::T, threads::Int

--- a/PRASCore.jl/src/Results/Results.jl
+++ b/PRASCore.jl/src/Results/Results.jl
@@ -13,7 +13,8 @@ import ..Systems: SystemModel, ZonedDateTime, Period,
 export
 
     # Metrics
-    ReliabilityMetric, LOLE, EUE, NEUE, LOLD, LOLEv, MeanEventDuration,
+    ReliabilityMetric, LOLE, EUE, NEUE, LOLD, LOLEv, 
+    MeanEventDuration, MaxEventDuration, MeanEventEnergy, MaxEventEnergy, 
     val, stderror,
 
     # Result specifications

--- a/PRASCore.jl/src/Results/Results.jl
+++ b/PRASCore.jl/src/Results/Results.jl
@@ -13,7 +13,7 @@ import ..Systems: SystemModel, ZonedDateTime, Period,
 export
 
     # Metrics
-    ReliabilityMetric, LOLE, EUE, NEUE, LOLD, LOLEv,
+    ReliabilityMetric, LOLE, EUE, NEUE, LOLD, LOLEv, MeanEventDuration,
     val, stderror,
 
     # Result specifications

--- a/PRASCore.jl/src/Results/ShortfallEvents.jl
+++ b/PRASCore.jl/src/Results/ShortfallEvents.jl
@@ -15,15 +15,18 @@ struct ShortfallEvents <: ResultSpec end
 struct ShortfallEvent
     start_idx::Int
     end_idx::Int
+    energy::Int
 
-    function ShortfallEvent(start_idx::Int, end_idx::Int)
+    function ShortfallEvent(start_idx::Int, end_idx::Int, energy::Int)
         start_idx > 0 || throw(DomainError(start_idx, "start_idx must be positive"))
         end_idx >= start_idx || throw(DomainError(end_idx, "end_idx must be >= start_idx"))
-        new(start_idx, end_idx)
+        energy >= 0 || throw(DomainError(energy, "energy must be non-negative"))
+        new(start_idx, end_idx, energy)
     end
 end
 
 duration_periods(ev::ShortfallEvent) = ev.end_idx - ev.start_idx + 1
+event_energy(ev::ShortfallEvent) = ev.energy
 
 mutable struct ShortfallEventsAccumulator{S} <: ResultAccumulator{ShortfallEvents}
 
@@ -32,16 +35,18 @@ mutable struct ShortfallEventsAccumulator{S} <: ResultAccumulator{ShortfallEvent
 
     in_system_event::Bool
     system_event_start::Int
+    system_event_energy::Int
 
     in_region_event::Vector{Bool}
     region_event_start::Vector{Int}
+    region_event_energy::Vector{Int}
 
     nperiods::Int
 end
 
 function accumulator(
     sys::SystemModel{N}, nsamples::Int, ::S
-) where {N,S<:Union{ShortfallEvents}}
+) where {N,S<:ShortfallEvents}
 
     nregions = length(sys.regions)
 
@@ -50,14 +55,16 @@ function accumulator(
 
     in_system_event = false
     system_event_start = 0
+    system_event_energy = 0
 
     in_region_event = falses(nregions)
     region_event_start = zeros(Int, nregions)
+    region_event_energy = zeros(Int, nregions)
 
     return ShortfallEventsAccumulator{S}(
         system_events, region_events,
-        in_system_event, system_event_start,
-        in_region_event, region_event_start,
+        in_system_event, system_event_start, system_event_energy,
+        in_region_event, region_event_start, region_event_energy,
         N)
 end
 
@@ -70,10 +77,10 @@ function merge!(
 end
 
 accumulatortype(::S) where {
-        S<:Union{ShortfallEvents}
+        S<:ShortfallEvents
     } = ShortfallEventsAccumulator{S}
 
-struct ShortfallEventsResult{N,L,T<:Period,S} <: AbstractShortfallEventResult{N,L,T}
+struct ShortfallEventsResult{N,L,T<:Period,P<:PowerUnit,E<:EnergyUnit,S} <: AbstractShortfallEventResult{N,L,T}
     regions::Regions
     timestamps::StepRange{ZonedDateTime,T}
 
@@ -126,9 +133,10 @@ end
 function finalize(
     acc::ShortfallEventsAccumulator{S},
     system::SystemModel{N,L,T,P,E},
-) where {N,L,T,P,E,S<:Union{ShortfallEvents}}
+) where {N,L,T,P,E,S<:ShortfallEvents}
 
-    return ShortfallEventsResult{N,L,T,S}(
+
+    return ShortfallEventsResult{N,L,T,P,E,S}(
         system.regions, system.timestamps,
         acc.system_events, acc.region_events)
 end
@@ -151,6 +159,65 @@ function MeanEventDuration(x::ShortfallEventsResult{N,L,T}, r::AbstractString) w
     return MeanEventDuration{N,L,T}(MeanEstimate(durations))
 end
 
+function MaxEventDuration(x::ShortfallEventsResult{N,L,T}) where {N,L,T}
+    durations = Float64[
+        isempty(events) ? 0.0 : maximum(duration_periods.(events))
+        for events in x.system_events
+    ]
+    return MaxEventDuration{N,L,T}(MeanEstimate(durations))
+end
+
+function MaxEventDuration(x::ShortfallEventsResult{N,L,T}, r::AbstractString) where {N,L,T}
+    i_r = findfirstunique(x.regions.names, r)
+    durations = Float64[
+        isempty(x.region_events[i_r, s]) ? 0.0 :
+            maximum(duration_periods.(x.region_events[i_r, s]))
+        for s in axes(x.region_events, 2)
+    ]
+    return MaxEventDuration{N,L,T}(MeanEstimate(durations))
+end
+
+function MeanEventEnergy(x::ShortfallEventsResult{N,L,T,P,E}) where {N,L,T,P,E}
+    p2e = conversionfactor(L, T, P, E)
+    energies = Float64[
+        isempty(events) ? 0.0 : mean(p2e .* event_energy.(events))
+        for events in x.system_events
+    ]
+    return MeanEventEnergy{N,L,T,E}(MeanEstimate(energies))
+end
+
+function MeanEventEnergy(x::ShortfallEventsResult{N,L,T,P,E}, r::AbstractString) where {N,L,T,P,E}
+    i_r = findfirstunique(x.regions.names, r)
+    p2e = conversionfactor(L, T, P, E)
+    energies = Float64[
+        isempty(x.region_events[i_r, s]) ? 0.0 :
+            mean(p2e .* event_energy.(x.region_events[i_r, s]))
+        for s in axes(x.region_events, 2)
+    ]
+    return MeanEventEnergy{N,L,T,E}(MeanEstimate(energies))
+end
+
+function MaxEventEnergy(x::ShortfallEventsResult{N,L,T,P,E}) where {N,L,T,P,E}
+    p2e = conversionfactor(L, T, P, E)
+    energies = Float64[
+        isempty(events) ? 0.0 : maximum(p2e .* event_energy.(events))
+        for events in x.system_events
+    ]
+    return MaxEventEnergy{N,L,T,E}(MeanEstimate(energies))
+end
+
+function MaxEventEnergy(x::ShortfallEventsResult{N,L,T,P,E}, r::AbstractString) where {N,L,T,P,E}
+    i_r = findfirstunique(x.regions.names, r)
+    p2e = conversionfactor(L, T, P, E)
+    energies = Float64[
+        isempty(x.region_events[i_r, s]) ? 0.0 :
+            maximum(p2e .* event_energy.(x.region_events[i_r, s]))
+        for s in axes(x.region_events, 2)
+    ]
+    return MaxEventEnergy{N,L,T,E}(MeanEstimate(energies))
+end
+
+
 function totalevents(x::ShortfallEventsResult)
     return sum(length, x.system_events)
 end
@@ -159,3 +226,4 @@ function totalevents(x::ShortfallEventsResult, r::AbstractString)
     i_r = findfirstunique(x.regions.names, r)
     return sum(length, view(x.region_events, i_r, :))
 end
+

--- a/PRASCore.jl/src/Results/ShortfallEvents.jl
+++ b/PRASCore.jl/src/Results/ShortfallEvents.jl
@@ -1,0 +1,135 @@
+"""
+    ShortfallEvents
+
+The `ShortfallEvents` result specification reports sample-level shortfall
+events, producing a `ShortfallEventsResult`.
+
+A shortfall event is a contiguous run of one or more simulation timesteps
+with positive shortfall.
+
+This result can be used to inspect event start/end times and to compute
+event-based reliability metrics such as [`LOLEv`](@ref).
+"""
+struct ShortfallEvents <: ResultSpec end
+struct DemandResponseShortfallEvents <: ResultSpec end
+
+struct ShortfallEvent
+    start_idx::Int
+    end_idx::Int
+
+    function ShortfallEvent(start_idx::Int, end_idx::Int)
+        start_idx > 0 || throw(DomainError(start_idx, "start_idx must be positive"))
+        end_idx >= start_idx || throw(DomainError(end_idx, "end_idx must be >= start_idx"))
+        new(start_idx, end_idx)
+    end
+end
+
+duration_periods(ev::ShortfallEvent) = ev.end_idx - ev.start_idx + 1
+
+mutable struct ShortfallEventsAccumulator{S} <: ResultAccumulator{ShortfallEvents}
+
+    system_events::Vector{Vector{ShortfallEvent}}
+    region_events::Matrix{Vector{ShortfallEvent}}
+
+    in_system_event::Bool
+    system_event_start::Int
+
+    in_region_event::Vector{Bool}
+    region_event_start::Vector{Int}
+
+    nperiods::Int
+end
+
+function accumulator(
+    sys::SystemModel{N}, nsamples::Int, ::S
+) where {N,S<:Union{ShortfallEvents,DemandResponseShortfallEvents}}
+
+    nregions = length(sys.regions)
+
+    system_events = [ShortfallEvent[] for _ in 1:nsamples]
+    region_events = [ShortfallEvent[] for _ in 1:nregions, _ in 1:nsamples]
+
+    in_system_event = false
+    system_event_start = 0
+
+    in_region_event = falses(nregions)
+    region_event_start = zeros(Int, nregions)
+
+    return ShortfallEventsAccumulator{S}(
+        system_events, region_events,
+        in_system_event, system_event_start,
+        in_region_event, region_event_start,
+        N)
+end
+
+function merge!(
+    x::ShortfallEventsAccumulator, y::ShortfallEventsAccumulator
+)
+    foreach(append!, x.system_events, y.system_events)
+    foreach(append!, x.region_events, y.region_events)
+    return
+end
+
+accumulatortype(::S) where {
+        S<:Union{ShortfallEvents,DemandResponseShortfallEvents}
+    } = ShortfallEventsAccumulator{S}
+
+struct ShortfallEventsResult{N,L,T<:Period,S} <: AbstractShortfallEventResult{N,L,T}
+    regions::Regions
+    timestamps::StepRange{ZonedDateTime,T}
+
+    system_events::Vector{Vector{ShortfallEvent}}
+    region_events::Matrix{Vector{ShortfallEvent}}
+end
+
+"""
+    getindex(x::ShortfallEventsResult, s::Int)
+
+Return the vector of system-wide shortfall events for sample `s`.
+"""
+function getindex(x::ShortfallEventsResult, s::Int)
+    return x.system_events[s]
+end
+
+"""
+    getindex(x::ShortfallEventsResult, r::AbstractString)
+
+Return a vector whose `s`th entry is the vector of shortfall events
+for region `r` in sample `s`.
+"""
+function getindex(x::ShortfallEventsResult, r::AbstractString)
+    i_r = findfirstunique(x.regions.names, r)
+    return [x.region_events[i_r, s] for s in axes(x.region_events, 2)]
+end
+
+"""
+    getindex(x::ShortfallEventsResult, r::AbstractString, s::Int)
+
+Return the vector of shortfall events for region `r` in sample `s`.
+"""
+function getindex(x::ShortfallEventsResult, r::AbstractString, s::Int)
+    i_r = findfirstunique(x.regions.names, r)
+    return x.region_events[i_r, s]
+end
+
+start_event_timestamp(x::ShortfallEventsResult, ev::ShortfallEvent) = x.timestamps[ev.start_idx]
+end_event_timestamp(x::ShortfallEventsResult, ev::ShortfallEvent) = x.timestamps[ev.end_idx]
+
+LOLEv(x::ShortfallEventsResult{N,L,T}) where {N,L,T} =
+    LOLEv{N,L,T}(MeanEstimate(length.(x.system_events)))
+
+function LOLEv(x::ShortfallEventsResult{N,L,T}, r::AbstractString) where {N,L,T}
+    i_r = findfirstunique(x.regions.names, r)
+    counts = [length(x.region_events[i_r, s]) for s in axes(x.region_events, 2)]
+    return LOLEv{N,L,T}(MeanEstimate(counts))
+end
+
+function finalize(
+    acc::ShortfallEventsAccumulator{S},
+    system::SystemModel{N,L,T,P,E},
+) where {N,L,T,P,E,S<:Union{ShortfallEvents,DemandResponseShortfallEvents}}
+
+    return ShortfallEventsResult{N,L,T,S}(
+        system.regions, system.timestamps,
+        acc.system_events, acc.region_events)
+end

--- a/PRASCore.jl/src/Results/ShortfallEvents.jl
+++ b/PRASCore.jl/src/Results/ShortfallEvents.jl
@@ -11,7 +11,6 @@ This result can be used to inspect event start/end times and to compute
 event-based reliability metrics such as [`LOLEv`](@ref).
 """
 struct ShortfallEvents <: ResultSpec end
-struct DemandResponseShortfallEvents <: ResultSpec end
 
 struct ShortfallEvent
     start_idx::Int
@@ -42,7 +41,7 @@ end
 
 function accumulator(
     sys::SystemModel{N}, nsamples::Int, ::S
-) where {N,S<:Union{ShortfallEvents,DemandResponseShortfallEvents}}
+) where {N,S<:Union{ShortfallEvents}}
 
     nregions = length(sys.regions)
 
@@ -71,7 +70,7 @@ function merge!(
 end
 
 accumulatortype(::S) where {
-        S<:Union{ShortfallEvents,DemandResponseShortfallEvents}
+        S<:Union{ShortfallEvents}
     } = ShortfallEventsAccumulator{S}
 
 struct ShortfallEventsResult{N,L,T<:Period,S} <: AbstractShortfallEventResult{N,L,T}
@@ -127,7 +126,7 @@ end
 function finalize(
     acc::ShortfallEventsAccumulator{S},
     system::SystemModel{N,L,T,P,E},
-) where {N,L,T,P,E,S<:Union{ShortfallEvents,DemandResponseShortfallEvents}}
+) where {N,L,T,P,E,S<:Union{ShortfallEvents}}
 
     return ShortfallEventsResult{N,L,T,S}(
         system.regions, system.timestamps,

--- a/PRASCore.jl/src/Results/ShortfallEvents.jl
+++ b/PRASCore.jl/src/Results/ShortfallEvents.jl
@@ -133,3 +133,30 @@ function finalize(
         system.regions, system.timestamps,
         acc.system_events, acc.region_events)
 end
+
+function MeanEventDuration(x::ShortfallEventsResult{N,L,T}) where {N,L,T}
+    durations = Float64[
+        isempty(events) ? 0.0 : mean(duration_periods.(events))
+        for events in x.system_events
+    ]
+    return MeanEventDuration{N,L,T}(MeanEstimate(durations))
+end
+
+function MeanEventDuration(x::ShortfallEventsResult{N,L,T}, r::AbstractString) where {N,L,T}
+    i_r = findfirstunique(x.regions.names, r)
+    durations = Float64[
+        isempty(x.region_events[i_r, s]) ? 0.0 :
+            mean(duration_periods.(x.region_events[i_r, s]))
+        for s in axes(x.region_events, 2)
+    ]
+    return MeanEventDuration{N,L,T}(MeanEstimate(durations))
+end
+
+function totalevents(x::ShortfallEventsResult)
+    return sum(length, x.system_events)
+end
+
+function totalevents(x::ShortfallEventsResult, r::AbstractString)
+    i_r = findfirstunique(x.regions.names, r)
+    return sum(length, view(x.region_events, i_r, :))
+end

--- a/PRASCore.jl/src/Results/ShortfallSamples.jl
+++ b/PRASCore.jl/src/Results/ShortfallSamples.jl
@@ -194,3 +194,46 @@ function finalize(
         system.regions, system.timestamps, acc.shortfall)
 
 end
+
+function _count_dropped_days_by_sample(flags_by_period_sample, day_ids)
+    nperiods, nsamples = size(flags_by_period_sample)
+    counts = zeros(Int, nsamples)
+
+    isempty(day_ids) && return counts
+
+    for s in 1:nsamples
+        current_day = day_ids[1]
+        day_has_shortfall = false
+        dropped_days = 0
+
+        for t in 1:nperiods
+            if day_ids[t] != current_day
+                dropped_days += day_has_shortfall
+                current_day = day_ids[t]
+                day_has_shortfall = false
+            end
+
+            day_has_shortfall |= flags_by_period_sample[t, s]
+        end
+
+        dropped_days += day_has_shortfall
+        counts[s] = dropped_days
+    end
+
+    return counts
+end
+
+function LOLD(x::ShortfallSamplesResult{N,L,T}) where {N,L,T}
+    flags = dropdims(sum(x.shortfall, dims=1) .> 0, dims=1)
+    day_ids = _day_ids(x.timestamps)
+    daycounts = _count_dropped_days_by_sample(flags, day_ids)
+    return LOLD{N,L,T}(MeanEstimate(daycounts))
+end
+
+function LOLD(x::ShortfallSamplesResult{N,L,T}, r::AbstractString) where {N,L,T}
+    i_r = findfirstunique(x.regions.names, r)
+    flags = Matrix(view(x.shortfall, i_r, :, :) .> 0)
+    day_ids = _day_ids(x.timestamps)
+    daycounts = _count_dropped_days_by_sample(flags, day_ids)
+    return LOLD{N,L,T}(MeanEstimate(daycounts))
+end

--- a/PRASCore.jl/src/Results/metrics.jl
+++ b/PRASCore.jl/src/Results/metrics.jl
@@ -164,3 +164,31 @@ function Base.show(io::IO, x::NEUE)
     print(io, "NEUE = ", x.neue, " ppm")
 
 end
+
+
+"""
+    LOLD
+
+`LOLD` reports loss of load days over a particular time period
+and regional extent.
+
+Contains both the estimated value itself as well as the standard error
+of that estimate, which can be extracted with `val` and `stderror`,
+respectively.
+"""
+struct LOLD{N, L, T <: Period} <: ReliabilityMetric
+    lold::MeanEstimate
+
+    function LOLD{N,L,T}(lold::MeanEstimate) where {N,L,T<:Period}
+        val(lold) >= 0 || throw(DomainError(val(lold),
+            "$(val(lold)) is not a valid expected count of event-days"))
+        new{N,L,T}(lold)
+    end
+end
+
+val(x::LOLD) = val(x.lold)
+stderror(x::LOLD) = stderror(x.lold)
+
+function Base.show(io::IO, x::LOLD{N,L,T}) where {N,L,T}
+    print(io, "LOLD = ", x.lold, " event-day")
+end

--- a/PRASCore.jl/src/Results/metrics.jl
+++ b/PRASCore.jl/src/Results/metrics.jl
@@ -220,3 +220,37 @@ stderror(x::LOLEv) = stderror(x.lolev)
 function Base.show(io::IO, x::LOLEv{N,L,T}) where {N,L,T}
     print(io, "LOLEv = ", x.lolev, " events")
 end
+
+
+"""
+    MeanEventDuration
+
+`MeanEventDuration` reports the expected average duration of shortfall
+events over a particular time period and regional extent.
+
+For each sample, the mean duration of all events in that sample
+is computed. Samples with no events are assigned a duration of 0. The final
+reported metric is the mean estimate across samples.
+
+Contains both the estimated value itself as well as the standard error
+of that estimate, which can be extracted with `val` and `stderror`,
+respectively.
+"""
+struct MeanEventDuration{N, L, T <: Period} <: ReliabilityMetric
+    duration::MeanEstimate
+
+    function MeanEventDuration{N,L,T}(duration::MeanEstimate) where {N,L,T<:Period}
+        val(duration) >= 0 || throw(DomainError(val(duration),
+            "$(val(duration)) is not a valid expected event duration"))
+        new{N,L,T}(duration)
+    end
+end
+
+val(x::MeanEventDuration) = val(x.duration)
+stderror(x::MeanEventDuration) = stderror(x.duration)
+
+function Base.show(io::IO, x::MeanEventDuration{N,L,T}) where {N,L,T}
+    t_symbol = unitsymbol(T)
+    print(io, "MeanEventDuration = ", x.duration, " ",
+          L == 1 ? t_symbol : "(" * string(L) * t_symbol * ")")
+end

--- a/PRASCore.jl/src/Results/metrics.jl
+++ b/PRASCore.jl/src/Results/metrics.jl
@@ -192,3 +192,31 @@ stderror(x::LOLD) = stderror(x.lold)
 function Base.show(io::IO, x::LOLD{N,L,T}) where {N,L,T}
     print(io, "LOLD = ", x.lold, " event-day")
 end
+
+
+"""
+    LOLEv
+
+`LOLEv` reports loss of load events over a particular time period
+and regional extent.
+
+Contains both the estimated value itself as well as the standard error
+of that estimate, which can be extracted with `val` and `stderror`,
+respectively.
+"""
+struct LOLEv{N, L, T <: Period} <: ReliabilityMetric
+    lolev::MeanEstimate
+
+    function LOLEv{N,L,T}(lolev::MeanEstimate) where {N,L,T<:Period}
+        val(lolev) >= 0 || throw(DomainError(val(lolev),
+            "$(val(lolev)) is not a valid expected count of events"))
+        new{N,L,T}(lolev)
+    end
+end
+
+val(x::LOLEv) = val(x.lolev)
+stderror(x::LOLEv) = stderror(x.lolev)
+
+function Base.show(io::IO, x::LOLEv{N,L,T}) where {N,L,T}
+    print(io, "LOLEv = ", x.lolev, " events")
+end

--- a/PRASCore.jl/src/Results/metrics.jl
+++ b/PRASCore.jl/src/Results/metrics.jl
@@ -22,7 +22,11 @@ MeanEstimate(mu::Real, sigma::Real, n::Int) = MeanEstimate(mu, sigma / sqrt(n))
 
 function MeanEstimate(xs::AbstractArray{<:Real})
     est = mean(xs)
-    return MeanEstimate(est, std(xs, mean=est), length(xs))
+    if length(xs) > 1
+        return MeanEstimate(est, std(xs, mean=est), length(xs))
+    else
+        return MeanEstimate(est)
+    end
 end
 
 val(est::MeanEstimate) = est.estimate
@@ -253,4 +257,102 @@ function Base.show(io::IO, x::MeanEventDuration{N,L,T}) where {N,L,T}
     t_symbol = unitsymbol(T)
     print(io, "MeanEventDuration = ", x.duration, " ",
           L == 1 ? t_symbol : "(" * string(L) * t_symbol * ")")
+end
+
+
+"""
+    MaxEventDuration
+
+`MaxEventDuration` reports the expected maximum duration of shortfall
+events over a particular time period and regional extent.
+
+For each sample, the maximum duration of all events in that sample
+is computed. Samples with no events are assigned a duration of 0. The final
+reported metric is the mean estimate across samples.
+
+Contains both the estimated value itself as well as the standard error
+of that estimate, which can be extracted with `val` and `stderror`,
+respectively.
+"""
+struct MaxEventDuration{N, L, T <: Period} <: ReliabilityMetric
+    duration::MeanEstimate
+
+    function MaxEventDuration{N,L,T}(duration::MeanEstimate) where {N,L,T<:Period}
+        val(duration) >= 0 || throw(DomainError(val(duration),
+            "$(val(duration)) is not a valid expected maximum event duration"))
+        new{N,L,T}(duration)
+    end
+end
+
+val(x::MaxEventDuration) = val(x.duration)
+stderror(x::MaxEventDuration) = stderror(x.duration)
+
+function Base.show(io::IO, x::MaxEventDuration{N,L,T}) where {N,L,T}
+    t_symbol = unitsymbol(T)
+    print(io, "MaxEventDuration = ", x.duration, " ",
+          L == 1 ? t_symbol : "(" * string(L) * t_symbol * ")")
+end
+
+
+"""
+    MeanEventEnergy
+
+`MeanEventEnergy` reports the expected average unserved energy of shortfall
+events over a particular time period and regional extent.
+
+For each sample, the mean energy of all events in that sample
+is computed. Samples with no events are assigned an energy of 0. The final
+reported metric is the mean estimate across samples.
+
+Contains both the estimated value itself as well as the standard error
+of that estimate, which can be extracted with `val` and `stderror`,
+respectively.
+"""
+struct MeanEventEnergy{N,L,T<:Period,E<:EnergyUnit} <: ReliabilityMetric
+    energy::MeanEstimate
+
+    function MeanEventEnergy{N,L,T,E}(energy::MeanEstimate) where {N,L,T<:Period,E<:EnergyUnit}
+        val(energy) >= 0 || throw(DomainError(val(energy),
+            "$(val(energy)) is not a valid expected event energy"))
+        new{N,L,T,E}(energy)
+    end
+end
+
+val(x::MeanEventEnergy) = val(x.energy)
+stderror(x::MeanEventEnergy) = stderror(x.energy)
+
+function Base.show(io::IO, x::MeanEventEnergy{N,L,T,E}) where {N,L,T,E}
+    print(io, "MeanEventEnergy = ", x.energy, " ", unitsymbol(E))
+end
+
+
+"""
+    MaxEventEnergy
+
+`MaxEventEnergy` reports the expected maximum unserved energy of shortfall
+events over a particular time period and regional extent.
+
+For each sample, the maximum event energy in that sample
+is computed. Samples with no events are assigned an energy of 0. The final
+reported metric is the mean estimate across samples.
+
+Contains both the estimated value itself as well as the standard error
+of that estimate, which can be extracted with `val` and `stderror`,
+respectively.
+"""
+struct MaxEventEnergy{N,L,T<:Period,E<:EnergyUnit} <: ReliabilityMetric
+    energy::MeanEstimate
+
+    function MaxEventEnergy{N,L,T,E}(energy::MeanEstimate) where {N,L,T<:Period,E<:EnergyUnit}
+        val(energy) >= 0 || throw(DomainError(val(energy),
+            "$(val(energy)) is not a valid expected maximum event energy"))
+        new{N,L,T,E}(energy)
+    end
+end
+
+val(x::MaxEventEnergy) = val(x.energy)
+stderror(x::MaxEventEnergy) = stderror(x.energy)
+
+function Base.show(io::IO, x::MaxEventEnergy{N,L,T,E}) where {N,L,T,E}
+    print(io, "MaxEventEnergy = ", x.energy, " ", unitsymbol(E))
 end

--- a/PRASCore.jl/src/Results/utils.jl
+++ b/PRASCore.jl/src/Results/utils.jl
@@ -43,22 +43,11 @@ end
 
 function _day_ids(timestamps)
     n = length(timestamps)
-    ids = Vector{Int}(undef, n)
+    n == 0 && return Int[]
 
-    n == 0 && return ids
-
-    current_day = Date(first(timestamps))
-    current_id = 1
-    ids[1] = current_id
-
-    for i in 2:n
-        d = Date(timestamps[i])
-        if d != current_day
-            current_day = d
-            current_id += 1
-        end
-        ids[i] = current_id
-    end
-
-    return ids
+    dates = Date.(timestamps)
+    changes = Vector{Bool}(undef, n)
+    changes[1] = true
+    changes[2:end] .= dates[2:end] .!= dates[1:end-1]
+    return cumsum(changes)
 end

--- a/PRASCore.jl/src/Results/utils.jl
+++ b/PRASCore.jl/src/Results/utils.jl
@@ -40,3 +40,25 @@ function findfirstunique(a::AbstractVector{T}, i::T) where T
     i_idx === nothing && throw(BoundsError(a))
     return i_idx
 end
+
+function _day_ids(timestamps)
+    n = length(timestamps)
+    ids = Vector{Int}(undef, n)
+
+    n == 0 && return ids
+
+    current_day = Date(first(timestamps))
+    current_id = 1
+    ids[1] = current_id
+
+    for i in 2:n
+        d = Date(timestamps[i])
+        if d != current_day
+            current_day = d
+            current_id += 1
+        end
+        ids[i] = current_id
+    end
+
+    return ids
+end

--- a/PRASCore.jl/src/Simulations/recording.jl
+++ b/PRASCore.jl/src/Simulations/recording.jl
@@ -522,6 +522,7 @@ function record!(
 ) where {N,L,T,P,E,S}
 
     isshortfall = false
+    totalshortfall = 0
     edges = problem.fp.edges
 
     for (r, dr_idxs) in zip(problem.region_unserved_edges, system.region_dr_idxs)
@@ -536,27 +537,48 @@ function record!(
         regionshortfall += dr_shortfall
         isregionshortfall = regionshortfall > 0
 
-        if isregionshortfall && !acc.in_region_event[r]
-            acc.in_region_event[r] = true
-            acc.region_event_start[r] = t
-        elseif !isregionshortfall && acc.in_region_event[r]
+        if isregionshortfall
+            totalshortfall += regionshortfall
+
+            if !acc.in_region_event[r]
+                acc.in_region_event[r] = true
+                acc.region_event_start[r] = t
+                acc.region_event_energy[r] = 0
+            end
+
+            acc.region_event_energy[r] += regionshortfall
+
+        elseif acc.in_region_event[r]
             push!(acc.region_events[r, sampleid],
-                  Results.ShortfallEvent(acc.region_event_start[r], t - 1))
+                  Results.ShortfallEvent(
+                      acc.region_event_start[r],
+                      t - 1,
+                      acc.region_event_energy[r]))
             acc.in_region_event[r] = false
             acc.region_event_start[r] = 0
+            acc.region_event_energy[r] = 0
         end
 
         isshortfall |= isregionshortfall
     end
 
-    if isshortfall && !acc.in_system_event
-        acc.in_system_event = true
-        acc.system_event_start = t
-    elseif !isshortfall && acc.in_system_event
+    if isshortfall
+        if !acc.in_system_event
+            acc.in_system_event = true
+            acc.system_event_start = t
+            acc.system_event_energy = 0
+        end
+        acc.system_event_energy += totalshortfall
+
+    elseif acc.in_system_event
         push!(acc.system_events[sampleid],
-              Results.ShortfallEvent(acc.system_event_start, t - 1))
+              Results.ShortfallEvent(
+                  acc.system_event_start,
+                  t - 1,
+                  acc.system_event_energy))
         acc.in_system_event = false
         acc.system_event_start = 0
+        acc.system_event_energy = 0
     end
 
     return
@@ -566,19 +588,28 @@ function reset!(acc::Results.ShortfallEventsAccumulator, sampleid::Int)
 
     if acc.in_system_event
         push!(acc.system_events[sampleid],
-              Results.ShortfallEvent(acc.system_event_start, acc.nperiods))
+              Results.ShortfallEvent(
+                  acc.system_event_start,
+                  acc.nperiods,
+                  acc.system_event_energy))
         acc.in_system_event = false
         acc.system_event_start = 0
+        acc.system_event_energy = 0
     end
 
     for r in eachindex(acc.in_region_event)
         if acc.in_region_event[r]
             push!(acc.region_events[r, sampleid],
-                  Results.ShortfallEvent(acc.region_event_start[r], acc.nperiods))
+                  Results.ShortfallEvent(
+                      acc.region_event_start[r],
+                      acc.nperiods,
+                      acc.region_event_energy[r]))
             acc.in_region_event[r] = false
             acc.region_event_start[r] = 0
+            acc.region_event_energy[r] = 0
         end
     end
 
     return
 end
+

--- a/PRASCore.jl/src/Simulations/recording.jl
+++ b/PRASCore.jl/src/Simulations/recording.jl
@@ -510,3 +510,75 @@ function record!(
 end
 
 reset!(acc::Results.DemandResponseEnergySamplesAccumulator, sampleid::Int) = nothing
+
+
+# ShortfallEvents
+
+function record!(
+    acc::Results.ShortfallEventsAccumulator{S},
+    system::SystemModel{N,L,T,P,E},
+    state::SystemState, problem::DispatchProblem,
+    sampleid::Int, t::Int
+) where {N,L,T,P,E,S}
+
+    isshortfall = false
+    edges = problem.fp.edges
+
+    for (r, dr_idxs) in zip(problem.region_unserved_edges, system.region_dr_idxs)
+
+        regionshortfall = init_regionshortfall(S, edges, r)
+
+        dr_shortfall = 0
+        for i in dr_idxs
+            dr_shortfall += state.drs_unservedenergy[i]
+        end
+
+        regionshortfall += dr_shortfall
+        isregionshortfall = regionshortfall > 0
+
+        if isregionshortfall && !acc.in_region_event[r]
+            acc.in_region_event[r] = true
+            acc.region_event_start[r] = t
+        elseif !isregionshortfall && acc.in_region_event[r]
+            push!(acc.region_events[r, sampleid],
+                  Results.ShortfallEvent(acc.region_event_start[r], t - 1))
+            acc.in_region_event[r] = false
+            acc.region_event_start[r] = 0
+        end
+
+        isshortfall |= isregionshortfall
+    end
+
+    if isshortfall && !acc.in_system_event
+        acc.in_system_event = true
+        acc.system_event_start = t
+    elseif !isshortfall && acc.in_system_event
+        push!(acc.system_events[sampleid],
+              Results.ShortfallEvent(acc.system_event_start, t - 1))
+        acc.in_system_event = false
+        acc.system_event_start = 0
+    end
+
+    return
+end
+
+function reset!(acc::Results.ShortfallEventsAccumulator, sampleid::Int)
+
+    if acc.in_system_event
+        push!(acc.system_events[sampleid],
+              Results.ShortfallEvent(acc.system_event_start, acc.nperiods))
+        acc.in_system_event = false
+        acc.system_event_start = 0
+    end
+
+    for r in eachindex(acc.in_region_event)
+        if acc.in_region_event[r]
+            push!(acc.region_events[r, sampleid],
+                  Results.ShortfallEvent(acc.region_event_start[r], acc.nperiods))
+            acc.in_region_event[r] = false
+            acc.region_event_start[r] = 0
+        end
+    end
+
+    return
+end

--- a/PRASCore.jl/src/Simulations/utils.jl
+++ b/PRASCore.jl/src/Simulations/utils.jl
@@ -249,7 +249,8 @@ function init_regionshortfall(
     edges,
     region) where {S <: Union{
                             Results.Shortfall,
-                            Results.ShortfallSamples}}
+                            Results.ShortfallSamples,
+                            Results.ShortfallEvents}}
     return edges[region].flow
 end
 

--- a/PRASCore.jl/test/Simulations/runtests.jl
+++ b/PRASCore.jl/test/Simulations/runtests.jl
@@ -590,5 +590,55 @@
         @test isapprox(sum(dr_shortfall_samples["Region 1",dts[5]])/1e4,TestData.threenode_dr_shortfall_samples/1e4, rtol=0.01)
     end
 
+    @testset "LOLD Results" begin
+        lold_1a = LOLD(shortfall2_1a)
+        regional_lold_1a = LOLD(shortfall2_1a, "Region")
+    
+        @test val(lold_1a) isa Float64
+        @test stderror(lold_1a) isa Float64
+        @test val(regional_lold_1a) isa Float64
+        @test stderror(regional_lold_1a) isa Float64
+    
+        @test val(lold_1a) >= 0
+        @test stderror(lold_1a) >= 0
+        @test val(regional_lold_1a) >= 0
+        @test stderror(regional_lold_1a) >= 0
+    
+        @test val(lold_1a) <= length(unique(Date.(shortfall2_1a.timestamps)))
+        @test val(regional_lold_1a) <= length(unique(Date.(shortfall2_1a.timestamps)))
+        @test val(lold_1a) >= val(regional_lold_1a)
+    
+        lold_1a5 = LOLD(shortfall2_1a5)
+        regional_lold_1a5 = LOLD(shortfall2_1a5, "Region")
+    
+        @test val(lold_1a5) <= length(unique(Date.(shortfall2_1a5.timestamps)))
+        @test val(regional_lold_1a5) <= length(unique(Date.(shortfall2_1a5.timestamps)))
+        @test val(lold_1a5) >= val(regional_lold_1a5)
+    
+        lold_1b = LOLD(shortfall2_1b)
+        regional_lold_1b = LOLD(shortfall2_1b, "Region")
+    
+        @test val(lold_1b) <= length(unique(Date.(shortfall2_1b.timestamps)))
+        @test val(regional_lold_1b) <= length(unique(Date.(shortfall2_1b.timestamps)))
+        @test val(lold_1b) >= val(regional_lold_1b)
+    
+        lold_3 = LOLD(shortfall2_3)
+        regional_lold_3 = LOLD(shortfall2_3, "Region A")
+    
+        @test val(lold_3) isa Float64
+        @test stderror(lold_3) isa Float64
+        @test val(regional_lold_3) isa Float64
+        @test stderror(regional_lold_3) isa Float64
+    
+        @test val(lold_3) >= 0
+        @test stderror(lold_3) >= 0
+        @test val(regional_lold_3) >= 0
+        @test stderror(regional_lold_3) >= 0
+    
+        @test val(lold_3) <= length(unique(Date.(shortfall2_3.timestamps)))
+        @test val(regional_lold_3) <= length(unique(Date.(shortfall2_3.timestamps)))
+        @test val(lold_3) >= val(regional_lold_3)
+    end
+
 
 end

--- a/PRASCore.jl/test/Simulations/runtests.jl
+++ b/PRASCore.jl/test/Simulations/runtests.jl
@@ -640,5 +640,30 @@
         @test val(lold_3) >= val(regional_lold_3)
     end
 
+    @testset "Shortfall Event Metrics" begin
+
+        @testset "Shortfall Event Metrics" begin
+            # Single-region system
+            @test val(LOLEv(events_1a)) >= 0
+            @test stderror(LOLEv(events_1a)) >= 0
+            @test val(MeanEventDuration(events_1a)) >= 0
+            @test stderror(MeanEventDuration(events_1a)) >= 0
+    
+            @test LOLEv(events_1a) ≈ LOLEv(events_1a, "Region")
+            @test MeanEventDuration(events_1a) ≈ MeanEventDuration(events_1a, "Region")
+    
+            # Multi-region system
+            @test val(LOLEv(events_3)) >= 0
+            @test val(MeanEventDuration(events_3)) >= 0
+            @test val(LOLEv(events_3, "Region A")) >= 0
+            @test val(MeanEventDuration(events_3, "Region A")) >= 0
+    
+            @test val(LOLEv(events_3)) >= val(LOLEv(events_3, "Region A"))
+    
+            @test PRAS.PRASCore.Results.totalevents(events_1a) >= 0
+            @test PRAS.PRASCore.Results.totalevents(events_3, "Region A") >= 0
+        end
+    end
+
 
 end

--- a/PRASCore.jl/test/Simulations/runtests.jl
+++ b/PRASCore.jl/test/Simulations/runtests.jl
@@ -32,6 +32,8 @@
     shortfall2_1a, _, flow2_1a, util2_1a, _ =
         assess(TestData.singlenode_a, simspec, resultspecs...)
 
+    events_1a, = assess(TestData.singlenode_a, simspec, ShortfallEvents()) 
+
     assess(TestData.singlenode_a_5min, smallsample, resultspecs...)
     shortfall_1a5, _, flow_1a5, util_1a5,
     shortfall2_1a5, _, flow2_1a5, util2_1a5, _ =
@@ -52,6 +54,8 @@
            StorageAvailability(), GeneratorStorageAvailability(),DemandResponseAvailability(),
            StorageEnergy(), GeneratorStorageEnergy(),DemandResponseEnergy(),
            StorageEnergySamples(), GeneratorStorageEnergySamples(),DemandResponseEnergySamples())
+    
+    events_3, = assess(TestData.threenode, simspec, ShortfallEvents())
 
     @testset "Shortfall Results" begin
 
@@ -593,77 +597,51 @@
     @testset "LOLD Results" begin
         lold_1a = LOLD(shortfall2_1a)
         regional_lold_1a = LOLD(shortfall2_1a, "Region")
-    
-        @test val(lold_1a) isa Float64
-        @test stderror(lold_1a) isa Float64
-        @test val(regional_lold_1a) isa Float64
-        @test stderror(regional_lold_1a) isa Float64
-    
+
         @test val(lold_1a) >= 0
-        @test stderror(lold_1a) >= 0
         @test val(regional_lold_1a) >= 0
-        @test stderror(regional_lold_1a) >= 0
-    
-        @test val(lold_1a) <= length(unique(Date.(shortfall2_1a.timestamps)))
-        @test val(regional_lold_1a) <= length(unique(Date.(shortfall2_1a.timestamps)))
         @test val(lold_1a) >= val(regional_lold_1a)
-    
-        lold_1a5 = LOLD(shortfall2_1a5)
-        regional_lold_1a5 = LOLD(shortfall2_1a5, "Region")
-    
-        @test val(lold_1a5) <= length(unique(Date.(shortfall2_1a5.timestamps)))
-        @test val(regional_lold_1a5) <= length(unique(Date.(shortfall2_1a5.timestamps)))
-        @test val(lold_1a5) >= val(regional_lold_1a5)
-    
-        lold_1b = LOLD(shortfall2_1b)
-        regional_lold_1b = LOLD(shortfall2_1b, "Region")
-    
-        @test val(lold_1b) <= length(unique(Date.(shortfall2_1b.timestamps)))
-        @test val(regional_lold_1b) <= length(unique(Date.(shortfall2_1b.timestamps)))
-        @test val(lold_1b) >= val(regional_lold_1b)
-    
-        lold_3 = LOLD(shortfall2_3)
-        regional_lold_3 = LOLD(shortfall2_3, "Region A")
-    
-        @test val(lold_3) isa Float64
-        @test stderror(lold_3) isa Float64
-        @test val(regional_lold_3) isa Float64
-        @test stderror(regional_lold_3) isa Float64
-    
-        @test val(lold_3) >= 0
-        @test stderror(lold_3) >= 0
-        @test val(regional_lold_3) >= 0
-        @test stderror(regional_lold_3) >= 0
-    
-        @test val(lold_3) <= length(unique(Date.(shortfall2_3.timestamps)))
-        @test val(regional_lold_3) <= length(unique(Date.(shortfall2_3.timestamps)))
-        @test val(lold_3) >= val(regional_lold_3)
+
+        # Manual system-wide LOLD check for single-region system A
+        day_ids_1a = Results._day_ids(shortfall2_1a.timestamps)
+        flags_1a = dropdims(sum(shortfall2_1a.shortfall, dims=1) .> 0, dims=1)
+        manual_daycounts_1a =
+            Results._count_dropped_days_by_sample(flags_1a, day_ids_1a)
+
+        @test isapprox(val(lold_1a), mean(manual_daycounts_1a); rtol=1e-10)
+
+        # Manual regional LOLD check for three-region system
+        lold_3_regionA = LOLD(shortfall2_3, "Region A")
+        i_r = findfirst(isequal("Region A"), shortfall2_3.regions.names)
+        day_ids_3 = Results._day_ids(shortfall2_3.timestamps)
+        flags_3_regionA = Matrix(view(shortfall2_3.shortfall, i_r, :, :) .> 0)
+        manual_daycounts_3_regionA =
+            Results._count_dropped_days_by_sample(flags_3_regionA, day_ids_3)
+
+        @test isapprox(val(lold_3_regionA), mean(manual_daycounts_3_regionA); rtol=1e-10)
     end
 
     @testset "Shortfall Event Metrics" begin
+        # Single-region system
+        @test val(LOLEv(events_1a)) >= 0
+        @test stderror(LOLEv(events_1a)) >= 0
+        @test val(MeanEventDuration(events_1a)) >= 0
+        @test stderror(MeanEventDuration(events_1a)) >= 0
 
-        @testset "Shortfall Event Metrics" begin
-            # Single-region system
-            @test val(LOLEv(events_1a)) >= 0
-            @test stderror(LOLEv(events_1a)) >= 0
-            @test val(MeanEventDuration(events_1a)) >= 0
-            @test stderror(MeanEventDuration(events_1a)) >= 0
-    
-            @test LOLEv(events_1a) ≈ LOLEv(events_1a, "Region")
-            @test MeanEventDuration(events_1a) ≈ MeanEventDuration(events_1a, "Region")
-    
-            # Multi-region system
-            @test val(LOLEv(events_3)) >= 0
-            @test val(MeanEventDuration(events_3)) >= 0
-            @test val(LOLEv(events_3, "Region A")) >= 0
-            @test val(MeanEventDuration(events_3, "Region A")) >= 0
-    
-            @test val(LOLEv(events_3)) >= val(LOLEv(events_3, "Region A"))
-    
-            @test PRAS.PRASCore.Results.totalevents(events_1a) >= 0
-            @test PRAS.PRASCore.Results.totalevents(events_3, "Region A") >= 0
-        end
+        @test LOLEv(events_1a) ≈ LOLEv(events_1a, "Region")
+        @test MeanEventDuration(events_1a) ≈ MeanEventDuration(events_1a, "Region")
+
+        # Multi-region system
+        @test val(LOLEv(events_3)) >= 0
+        @test val(MeanEventDuration(events_3)) >= 0
+        @test val(LOLEv(events_3, "Region A")) >= 0
+        @test val(MeanEventDuration(events_3, "Region A")) >= 0
+
+        @test val(LOLEv(events_3)) >= val(LOLEv(events_3, "Region A"))
+
+        @test Results.totalevents(events_1a) >= 0
+        @test Results.totalevents(events_3, "Region A") >= 0
+
     end
-
 
 end

--- a/PRASCore.jl/test/Simulations/runtests.jl
+++ b/PRASCore.jl/test/Simulations/runtests.jl
@@ -630,6 +630,38 @@
 
         @test LOLEv(events_1a) ≈ LOLEv(events_1a, "Region")
         @test MeanEventDuration(events_1a) ≈ MeanEventDuration(events_1a, "Region")
+        @test MaxEventDuration(events_1a) ≈ MaxEventDuration(events_1a, "Region")
+        @test MeanEventEnergy(events_1a) ≈ MeanEventEnergy(events_1a, "Region")
+        @test MaxEventEnergy(events_1a) ≈ MaxEventEnergy(events_1a, "Region")
+
+        manual_lolev_1a = mean(length.(events_1a.system_events))
+        @test isapprox(val(LOLEv(events_1a)), manual_lolev_1a; rtol=1e-10)
+
+        manual_meandur_1a = mean([
+            isempty(evts) ? 0.0 : mean(Results.duration_periods.(evts))
+            for evts in events_1a.system_events
+        ])
+        @test isapprox(val(MeanEventDuration(events_1a)), manual_meandur_1a; rtol=1e-10)
+
+        manual_maxdur_1a = mean([
+            isempty(evts) ? 0.0 : maximum(Results.duration_periods.(evts))
+            for evts in events_1a.system_events
+        ])
+        @test isapprox(val(MaxEventDuration(events_1a)), manual_maxdur_1a; rtol=1e-10)
+
+        p2e_1a = PRASCore.Systems.conversionfactor(1, Hour, PRASCore.Systems.MW, PRASCore.Systems.MWh)
+
+        manual_meanenergy_1a = mean([
+            isempty(evts) ? 0.0 : mean(p2e_1a .* Results.event_energy.(evts))
+            for evts in events_1a.system_events
+        ])
+        @test isapprox(val(MeanEventEnergy(events_1a)), manual_meanenergy_1a; rtol=1e-10)
+
+        manual_maxenergy_1a = mean([
+            isempty(evts) ? 0.0 : maximum(p2e_1a .* Results.event_energy.(evts))
+            for evts in events_1a.system_events
+        ])
+        @test isapprox(val(MaxEventEnergy(events_1a)), manual_maxenergy_1a; rtol=1e-10)
 
         # Multi-region system
         @test val(LOLEv(events_3)) >= 0

--- a/PRASFiles.jl/src/PRASFiles.jl
+++ b/PRASFiles.jl/src/PRASFiles.jl
@@ -2,9 +2,15 @@ module PRASFiles
 
 import PRASCore.Systems: SystemModel, Regions, Interfaces,
                          Generators, Storages, GeneratorStorages, DemandResponses, Lines,
-                         timeunits, powerunits, energyunits, unitsymbol
+                         timeunits, powerunits, energyunits, unitsymbol, conversionfactor
 
-import PRASCore.Results: EUE, LOLE, NEUE, ShortfallResult, ShortfallSamplesResult, AbstractShortfallResult, Result
+import PRASCore.Results:
+    EUE, LOLE, NEUE, LOLEv,
+    MeanEventDuration, MaxEventDuration,
+    MeanEventEnergy, MaxEventEnergy,
+    ShortfallResult, ShortfallSamplesResult, ShortfallEventsResult,
+    ShortfallEvent,
+    AbstractShortfallResult, Result, totalevents
 import StatsBase: mean
 import Dates: @dateformat_str, format, now
 import TimeZones: ZonedDateTime
@@ -18,6 +24,7 @@ import JSON3: pretty
 
 export savemodel
 export saveshortfall
+export saveevents
 export read_attrs
 
 include("Systems/read.jl")

--- a/PRASFiles.jl/src/Results/utils.jl
+++ b/PRASFiles.jl/src/Results/utils.jl
@@ -58,6 +58,79 @@ function NEUEResult(shortfall::AbstractShortfallResult; region::Union{Nothing, S
     )
 end
 
+struct LOLEvResult
+    mean::Float64
+    stderror::Float64
+end
+
+function LOLEvResult(events::ShortfallEventsResult; region::Union{Nothing, String} = nothing)
+    lolev = (region === nothing) ? LOLEv(events) : LOLEv(events, region)
+    return LOLEvResult(
+        lolev.lolev.estimate,
+        lolev.lolev.standarderror,
+    )
+end
+
+struct MeanEventDurationResult
+    mean::Float64
+    stderror::Float64
+end
+
+function MeanEventDurationResult(events::ShortfallEventsResult; region::Union{Nothing, String} = nothing)
+    duration = (region === nothing) ? MeanEventDuration(events) : MeanEventDuration(events, region)
+    return MeanEventDurationResult(
+        duration.duration.estimate,
+        duration.duration.standarderror,
+    )
+end
+
+struct MaxEventDurationResult
+    mean::Float64
+    stderror::Float64
+end
+
+function MaxEventDurationResult(events::ShortfallEventsResult; region::Union{Nothing, String} = nothing)
+    duration = (region === nothing) ? MaxEventDuration(events) : MaxEventDuration(events, region)
+    return MaxEventDurationResult(
+        duration.duration.estimate,
+        duration.duration.standarderror,
+    )
+end
+
+struct MeanEventEnergyResult
+    mean::Float64
+    stderror::Float64
+end
+
+function MeanEventEnergyResult(events::ShortfallEventsResult; region::Union{Nothing, String} = nothing)
+    energy = (region === nothing) ? MeanEventEnergy(events) : MeanEventEnergy(events, region)
+    return MeanEventEnergyResult(
+        energy.energy.estimate,
+        energy.energy.standarderror,
+    )
+end
+
+struct MaxEventEnergyResult
+    mean::Float64
+    stderror::Float64
+end
+
+function MaxEventEnergyResult(events::ShortfallEventsResult; region::Union{Nothing, String} = nothing)
+    energy = (region === nothing) ? MaxEventEnergy(events) : MaxEventEnergy(events, region)
+    return MaxEventEnergyResult(
+        energy.energy.estimate,
+        energy.energy.standarderror,
+    )
+end
+
+struct EventRecord
+    sample_id::Int64
+    start_timestamp::ZonedDateTime
+    end_timestamp::ZonedDateTime
+    duration_periods::Int64
+    energy::Float64
+end
+
 struct RegionResult
     name::String
     eue::EUEResult
@@ -70,6 +143,17 @@ struct RegionResult
     shortfall_timestamps::Vector{ZonedDateTime}
 end
 
+struct RegionEventResult
+    name::String
+    lolev::LOLEvResult
+    mean_event_duration::MeanEventDurationResult
+    max_event_duration::MaxEventDurationResult
+    mean_event_energy::MeanEventEnergyResult
+    max_event_energy::MaxEventEnergyResult
+    total_events::Int64
+    events::Vector{EventRecord}
+end
+
 struct SystemResult
     num_samples::Int64
     type_params::TypeParams
@@ -79,6 +163,21 @@ struct SystemResult
     lole::LOLEResult
     neue::NEUEResult
     region_results::Vector{RegionResult}
+end
+
+struct SystemEventResult
+    num_samples::Int64
+    type_params::TypeParams
+    sys_attributes::Dict{String, String}
+    timestamps::Vector{ZonedDateTime}
+    lolev::LOLEvResult
+    mean_event_duration::MeanEventDurationResult
+    max_event_duration::MaxEventDurationResult
+    mean_event_energy::MeanEventEnergyResult
+    max_event_energy::MaxEventEnergyResult
+    total_events::Int64
+    system_events::Vector{EventRecord}
+    region_results::Vector{RegionEventResult}
 end
 
 function get_shortfall_mean(shortfall::ShortfallResult)
@@ -97,6 +196,51 @@ function get_nsamples(shortfall::ShortfallSamplesResult)
     return size(shortfall.shortfall,3)
 end
 
+function get_eventrecords(
+    events_by_sample::Vector{Vector{ShortfallEvent}},
+    timestamps,
+    p2e,
+)
+    records = EventRecord[]
+
+    for (sample_id, evts) in enumerate(events_by_sample)
+        for ev in evts
+            push!(records, EventRecord(
+                sample_id,
+                timestamps[ev.start_idx],
+                timestamps[ev.end_idx],
+                ev.end_idx - ev.start_idx + 1,
+                p2e * ev.energy,
+            ))
+        end
+    end
+
+    return records
+end
+
+function get_eventrecords(
+    events::ShortfallEventsResult{N,L,T,P,E},
+    region::String,
+) where {N,L,T,P,E}
+    i_r = findfirst(isequal(region), events.regions.names)
+    p2e = conversionfactor(L, T, P, E)
+
+    records = EventRecord[]
+    for sample_id in axes(events.region_events, 2)
+        for ev in events.region_events[i_r, sample_id]
+            push!(records, EventRecord(
+                sample_id,
+                events.timestamps[ev.start_idx],
+                events.timestamps[ev.end_idx],
+                ev.end_idx - ev.start_idx + 1,
+                p2e * ev.energy,
+            ))
+        end
+    end
+
+    return records
+end
+
 # Define structtypes for different structs defined above
 StructType(::Type{TypeParams}) = Struct()
 StructType(::Type{EUEResult}) = Struct()
@@ -104,3 +248,12 @@ StructType(::Type{NEUEResult}) = Struct()
 StructType(::Type{LOLEResult}) = Struct()
 StructType(::Type{RegionResult}) = OrderedStruct()
 StructType(::Type{SystemResult}) = OrderedStruct()
+
+StructType(::Type{LOLEvResult}) = Struct()
+StructType(::Type{MeanEventDurationResult}) = Struct()
+StructType(::Type{MaxEventDurationResult}) = Struct()
+StructType(::Type{MeanEventEnergyResult}) = Struct()
+StructType(::Type{MaxEventEnergyResult}) = Struct()
+StructType(::Type{EventRecord}) = Struct()
+StructType(::Type{RegionEventResult}) = OrderedStruct()
+StructType(::Type{SystemEventResult}) = OrderedStruct()

--- a/PRASFiles.jl/src/Results/write.jl
+++ b/PRASFiles.jl/src/Results/write.jl
@@ -101,3 +101,94 @@ function saveshortfall(
 
     error("saveshortfall is not implemented for $(typeof(shortfall))")
 end
+
+function generate_eventresult(
+    events::ShortfallEventsResult{N,L,T,P,E},
+    pras_sys::SystemModel,
+) where {N,L,T,P,E}
+
+    p2e = conversionfactor(L, T, P, E)
+
+    region_results = RegionEventResult[]
+    for reg_name in pras_sys.regions.names
+        push!(region_results,
+            RegionEventResult(
+                reg_name,
+                LOLEvResult(events, region = reg_name),
+                MeanEventDurationResult(events, region = reg_name),
+                MaxEventDurationResult(events, region = reg_name),
+                MeanEventEnergyResult(events, region = reg_name),
+                MaxEventEnergyResult(events, region = reg_name),
+                totalevents(events, reg_name),
+                get_eventrecords(events, reg_name),
+            )
+        )
+    end
+
+    sys_result = SystemEventResult(
+        length(events.system_events),
+        TypeParams(pras_sys),
+        pras_sys.attrs,
+        collect(events.timestamps),
+        LOLEvResult(events),
+        MeanEventDurationResult(events),
+        MaxEventDurationResult(events),
+        MeanEventEnergyResult(events),
+        MaxEventEnergyResult(events),
+        totalevents(events),
+        get_eventrecords(events.system_events, events.timestamps, p2e),
+        region_results,
+    )
+
+    return sys_result
+end
+
+"""
+    saveevents(
+        events::ShortfallEventsResult,
+        pras_sys::SystemModel,
+        outfile::String,
+    )
+
+Save `ShortfallEventsResult` in JSON format, including both summary event
+metrics and raw event records.
+
+# Arguments
+
+  - `events::ShortfallEventsResult`: PRAS shortfall events result
+  - `pras_sys::SystemModel`: PRAS SystemModel
+  - `outfile::String`: Location to save the event results
+
+# Returns
+
+  - Location where the event results are exported in JSON format.
+"""
+function saveevents(
+    events::ShortfallEventsResult,
+    pras_sys::SystemModel,
+    outfile::String,
+)
+
+    dt_now = format(now(), "dd-u-yy-H-M-S")
+    export_location = joinpath(outfile, dt_now)
+    if !(isdir(export_location))
+        mkpath(export_location)
+    end
+
+    event_result = generate_eventresult(events, pras_sys)
+    open(joinpath(export_location, "pras_event_results.json"), "w") do io
+        pretty(io, event_result)
+    end
+
+    @info "Successfully exported PRAS ShortfallEventsResult here: $(export_location)"
+    return export_location
+end
+
+function saveevents(
+    events::R,
+    pras_sys::SystemModel,
+    outfile::String,
+) where {R <: Result}
+
+    error("saveevents is not implemented for $(typeof(events))")
+end

--- a/PRASFiles.jl/src/Results/write.jl
+++ b/PRASFiles.jl/src/Results/write.jl
@@ -104,13 +104,22 @@ end
 
 function generate_eventresult(
     events::ShortfallEventsResult{N,L,T,P,E},
-    pras_sys::SystemModel,
+    pras_sys::SystemModel;
+    include_events::Bool = false,
 ) where {N,L,T,P,E}
 
     p2e = conversionfactor(L, T, P, E)
 
+    system_event_records = include_events ?
+        get_eventrecords(events.system_events, events.timestamps, p2e) :
+        EventRecord[]
+
     region_results = RegionEventResult[]
     for reg_name in pras_sys.regions.names
+        region_event_records = include_events ?
+            get_eventrecords(events, reg_name) :
+            EventRecord[]
+
         push!(region_results,
             RegionEventResult(
                 reg_name,
@@ -120,7 +129,7 @@ function generate_eventresult(
                 MeanEventEnergyResult(events, region = reg_name),
                 MaxEventEnergyResult(events, region = reg_name),
                 totalevents(events, reg_name),
-                get_eventrecords(events, reg_name),
+                region_event_records,
             )
         )
     end
@@ -136,7 +145,7 @@ function generate_eventresult(
         MeanEventEnergyResult(events),
         MaxEventEnergyResult(events),
         totalevents(events),
-        get_eventrecords(events.system_events, events.timestamps, p2e),
+        system_event_records,
         region_results,
     )
 
@@ -162,11 +171,18 @@ metrics and raw event records.
 # Returns
 
   - Location where the event results are exported in JSON format.
+
+# Keywords
+
+    - `include_events::Bool = false`: If `true`, include full raw event records
+    at the system and regional levels. If `false`, only summary event metrics
+    and counts are exported.
 """
 function saveevents(
     events::ShortfallEventsResult,
     pras_sys::SystemModel,
-    outfile::String,
+    outfile::String;
+    include_events::Bool = false,
 )
 
     dt_now = format(now(), "dd-u-yy-H-M-S")
@@ -175,7 +191,7 @@ function saveevents(
         mkpath(export_location)
     end
 
-    event_result = generate_eventresult(events, pras_sys)
+    event_result = generate_eventresult(events, pras_sys; include_events = include_events)
     open(joinpath(export_location, "pras_event_results.json"), "w") do io
         pretty(io, event_result)
     end
@@ -187,7 +203,8 @@ end
 function saveevents(
     events::R,
     pras_sys::SystemModel,
-    outfile::String,
+    outfile::String;
+    include_events::Bool = false,
 ) where {R <: Result}
 
     error("saveevents is not implemented for $(typeof(events))")

--- a/docs/src/PRASCore/api.md
+++ b/docs/src/PRASCore/api.md
@@ -46,4 +46,7 @@ PRASCore.Results.LOLD
 PRASCore.Results.ShortfallEvents
 PRASCore.Results.LOLEv
 PRASCore.Results.MeanEventDuration
+PRASCore.Results.MaxEventDuration
+PRASCore.Results.MeanEventEnergy
+PRASCore.Results.MaxEventEnergy
 ```

--- a/docs/src/PRASCore/api.md
+++ b/docs/src/PRASCore/api.md
@@ -42,4 +42,8 @@ PRASCore.Results.DemandResponseAvailability
 PRASCore.Results.DemandResponseEnergy
 PRASCore.Results.DemandResponseEnergySamples
 PRASCore.Results.LineAvailability
+PRASCore.Results.LOLD
+PRASCore.Results.ShortfallEvents
+PRASCore.Results.LOLEv
+PRASCore.Results.MeanEventDuration
 ```


### PR DESCRIPTION
This PR implements the following metrics: 
- [x]  **LOLD**: as defined in [1]
- [x]  **LOLEv**: as defined in [2]

With the implementation of the above, all metrics defined in [2] are included in PRAS

This PR also introduces ShortfallEvents in order to simplify individual shortfall event analysis and enable event-based metrics. 
The following metrics commonly used in analysis are then implemented: 
- [x] MeanEventDuration, MaxEventDurationResult, MeanEventEnergyResult, MaxEventEnergyResult

References: 
[1] “Clarifying the interpretation and use of the LOLE Resource Adequacy Metric,” 
[2] "Probabilistic Adequacy and Measures", NERC